### PR TITLE
feat: harden normalization logging schema

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Literal, Mapping, Sequence, cast
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from .logging_utils import LOGGER, log_norm_error
+from .logging_utils import log_norm_error
 from .normalize import (
     NAME_ERROR,
     SpecialSchoolsProvider,
@@ -211,23 +211,12 @@ def to_student_normalized(
     )
 
     if incoming_student_type is not None:
-        try:
-            incoming_normalized = _normalize_student_type_value(incoming_student_type)
-        except ValueError:
-            log_norm_error(
-                "student_type",
-                incoming_student_type,
-                "مقدار ورودی نامعتبر",
-                "student_type.invalid_input",
-            )
-        else:
-            if incoming_normalized != derived_student_type:
-                log_norm_error(
-                    "student_type",
-                    incoming_student_type,
-                    "ناسازگاری با مقدار محاسبه‌شده",
-                    "student_type.mismatch",
-                )
+        log_norm_error(
+            "student_type",
+            incoming_student_type,
+            "مقدار ورودی نادیده گرفته شد",
+            "student_type.ignored_input",
+        )
 
     payload: Dict[str, Any] = {
         "gender": gender_raw,
@@ -243,19 +232,9 @@ def to_student_normalized(
 
     if name_raw is not None:
         try:
-            normalized_name = normalize_name(name_raw)
+            normalize_name(name_raw)
         except ValueError:
             log_norm_error("name", name_raw, NAME_ERROR, "name.invalid")
-        else:
-            if normalized_name is None and name_raw not in (None, "", " "):
-                LOGGER.warning(
-                    "name_normalization",
-                    extra={
-                        "event": "name_normalization",
-                        "field": "name",
-                        "original": "***",
-                    },
-                )
     return model
 
 

--- a/src/core/normalize.py
+++ b/src/core/normalize.py
@@ -273,9 +273,17 @@ def normalize_name(value: object | None) -> str | None:
 
     text = normalize_digits(str(value))
     text = unicodedata.normalize("NFKC", text)
-    text = text.replace("ك", "ک").replace("ي", "ی")
-    text = _ZERO_WIDTH_PATTERN.sub("", text)
-    stripped = text.strip()
+    replacements = (("ك", "ک"), ("ي", "ی"))
+    adjusted_text = text
+    adjusted = False
+    for src, dest in replacements:
+        if src in adjusted_text:
+            adjusted = True
+            adjusted_text = adjusted_text.replace(src, dest)
+    if adjusted:
+        log_norm_error("name", value, "تبدیل حروف عربی به فارسی", "name.arabic_letters")
+    adjusted_text = _ZERO_WIDTH_PATTERN.sub("", adjusted_text)
+    stripped = adjusted_text.strip()
     collapsed = " ".join(stripped.split())
     if not collapsed:
         log_norm_error("name", value, "نام پس از پاکسازی تهی شد", "name.empty_after_clean")


### PR DESCRIPTION
## Summary
- add an APP_ENV-aware salt selector so tests can override national ID hashing without affecting production
- enforce a single structured logging payload, canonical mobile masks, and richer name normalization warnings while ignoring inbound student_type values
- expand normalization tests to verify the new schema, hashing determinism, sanitized payloads, and Arabic/Persian name adjustments

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_cov --cov=src.core.normalize --cov=src.core.models --cov-report=term-missing tests/test_logging_payloads.py tests/test_normalization_branches.py tests/test_normalization.py tests/test_normalization_checksum.py


------
https://chatgpt.com/codex/tasks/task_e_68d2ac878f5483218e446f20edea0666