### PR TITLE
Add metrics allowlist flow and real Redis performance harness

### DIFF
--- a/src/hardened_api/middleware.py
+++ b/src/hardened_api/middleware.py
@@ -347,7 +347,7 @@ class IdempotencyMiddleware(BaseHTTPMiddleware):
         self._state = state
 
     async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
-        if request.method != "POST" or request.url.path != "/allocations":
+        if request.method != "POST" or request.url.path not in {"/allocations", "/counter/allocate"}:
             return await call_next(request)
         header = request.headers.get("Idempotency-Key")
         if not header:

--- a/src/hardened_api/observability.py
+++ b/src/hardened_api/observability.py
@@ -117,6 +117,11 @@ _metrics_registry = {
         "Total Redis retry attempts by outcome",
         ["op", "outcome"],
     ),
+    "metrics_scrape_total": Counter(
+        "metrics_scrape_total",
+        "Metrics endpoint scrape outcomes",
+        ["outcome"],
+    ),
     "redis_operation_latency_seconds": Histogram(
         "redis_operation_latency_seconds",
         "Redis operation latency",

--- a/src/hardened_api/redis_support.py
+++ b/src/hardened_api/redis_support.py
@@ -82,6 +82,14 @@ class RedisNamespaces:
     def jwt_deny(self, jti: str) -> str:
         return f"{self.base}:jwt_deny:{jti}"
 
+    # Phase 2 counter namespaces -------------------------------------------------
+
+    def counter_sequence(self, year_code: str, gender: int) -> str:
+        return f"{self.base}:counter:seq:{year_code}:{gender}"
+
+    def counter_student(self, year_code: str, student_id: str) -> str:
+        return f"{self.base}:counter:student:{year_code}:{student_id}"
+
 
 class RedisOperationError(RuntimeError):
     """Domain specific Redis error after retries are exhausted."""

--- a/src/opentelemetry/__init__.py
+++ b/src/opentelemetry/__init__.py
@@ -1,0 +1,4 @@
+"""Minimal opentelemetry stub for tests."""
+from . import trace  # noqa: F401
+
+__all__ = ["trace"]

--- a/src/opentelemetry/trace.py
+++ b/src/opentelemetry/trace.py
@@ -1,0 +1,43 @@
+"""Minimal trace API stub used in tests when opentelemetry is unavailable."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class Span:
+    name: str
+    kind: str | None = None
+    attributes: dict[str, object] | None = None
+    start_time: float = time.time()
+
+    def set_attribute(self, key: str, value: object) -> None:
+        if self.attributes is None:
+            self.attributes = {}
+        self.attributes[key] = value
+
+    def end(self) -> None:  # pragma: no cover - noop
+        return None
+
+
+class _Tracer:
+    def start_span(
+        self,
+        name: str,
+        *,
+        kind: str | None = None,
+        attributes: dict[str, object] | None = None,
+    ) -> Span:
+        return Span(name=name, kind=kind, attributes=dict(attributes or {}))
+
+
+def get_tracer(_name: str) -> _Tracer:
+    return _Tracer()
+
+
+class SpanKind:
+    SERVER = "SERVER"
+
+
+__all__ = ["Span", "SpanKind", "get_tracer"]

--- a/src/phase2_counter_service/academic_year.py
+++ b/src/phase2_counter_service/academic_year.py
@@ -1,0 +1,42 @@
+"""Academic year code provider used by the counter runtime."""
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass
+from typing import Mapping
+
+from src.core.normalize import normalize_digits
+
+
+def _strip_zw(text: str) -> str:
+    return "".join(ch for ch in text if ord(ch) not in {0x200c, 0x200d, 0x200e, 0x200f})
+
+
+@dataclass(slots=True)
+class AcademicYearProvider:
+    """Resolve canonical two-digit year codes for roster operations."""
+
+    code_map: Mapping[str, str]
+
+    def code_for(self, year: str | int) -> str:
+        """Return the canonical year code for the provided input."""
+
+        raw = str(year) if year is not None else ""
+        normalized = normalize_digits(unicodedata.normalize("NFKC", raw))
+        normalized = _strip_zw(normalized).strip()
+        if not normalized or not normalized.isdigit():
+            raise ValueError("سال نامعتبر است")
+        if normalized in self.code_map:
+            code = self.code_map[normalized]
+        else:
+            if len(normalized) < 4:
+                raise ValueError("سال نامعتبر است")
+            code = normalized[-2:]
+        code = normalize_digits(unicodedata.normalize("NFKC", code))
+        code = _strip_zw(code).strip()
+        if not code.isdigit() or len(code) != 2:
+            raise ValueError("کد سال نامعتبر است")
+        return code
+
+
+__all__ = ["AcademicYearProvider"]

--- a/src/phase2_counter_service/counter_runtime.py
+++ b/src/phase2_counter_service/counter_runtime.py
@@ -1,0 +1,319 @@
+"""Redis-backed counter allocation runtime for Phase 2."""
+from __future__ import annotations
+
+import json
+import logging
+import unicodedata
+from dataclasses import dataclass
+from hashlib import blake2s
+from typing import Any, Mapping
+
+from src.core.normalize import normalize_digits
+from src.hardened_api.redis_support import RedisExecutor, RedisLike, RedisNamespaces
+
+from .academic_year import AcademicYearProvider
+from .runtime_metrics import CounterRuntimeMetrics
+from .validation import COUNTER_PREFIX, COUNTER_PATTERN
+
+logger = logging.getLogger("counter.runtime")
+
+
+def _strip_controls(value: str) -> str:
+    return "".join(
+        ch for ch in value if ord(ch) not in {0x200c, 0x200d, 0x200e, 0x200f, 0xfeff}
+    )
+
+
+def _normalize_identifier(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = unicodedata.normalize("NFKC", text)
+    text = _strip_controls(text)
+    text = text.strip()
+    if not text:
+        raise ValueError("شناسه دانش‌آموز نامعتبر است")
+    return text
+
+
+def _normalize_int_field(value: Any, *, field: str, allowed: set[int]) -> int:
+    text = "" if value is None else str(value)
+    normalized = normalize_digits(unicodedata.normalize("NFKC", text))
+    normalized = _strip_controls(normalized).strip()
+    if not normalized.isdigit():
+        raise ValueError(f"{field} نامعتبر است")
+    parsed = int(normalized)
+    if parsed not in allowed:
+        raise ValueError(f"{field} نامعتبر است")
+    return parsed
+
+
+def _hash_student(student_id: str, *, salt: str) -> str:
+    digest = blake2s(key=salt.encode("utf-8"), digest_size=16)
+    digest.update(student_id.encode("utf-8"))
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class CounterResult:
+    counter: str
+    year_code: str
+    status: str
+
+
+class CounterRuntimeError(Exception):
+    def __init__(self, code: str, message_fa: str, *, details: str | None = None) -> None:
+        super().__init__(message_fa)
+        self.code = code
+        self.message_fa = message_fa
+        self.details = details
+
+
+class CounterRuntime:
+    """High-level orchestrator for counter allocation via Redis."""
+
+    def __init__(
+        self,
+        *,
+        redis: RedisLike,
+        namespaces: RedisNamespaces,
+        executor: RedisExecutor,
+        metrics: CounterRuntimeMetrics,
+        year_provider: AcademicYearProvider,
+        hash_salt: str,
+        max_serial: int = 9999,
+        placeholder_ttl_ms: int = 5000,
+        wait_attempts: int = 5,
+        wait_base_ms: int = 20,
+        wait_max_ms: int = 200,
+    ) -> None:
+        self._redis = redis
+        self._namespaces = namespaces
+        self._executor = executor
+        self._metrics = metrics
+        self._year_provider = year_provider
+        self._hash_salt = hash_salt
+        self._max_serial = max_serial
+        self._placeholder_ttl = max(100, placeholder_ttl_ms)
+        self._wait_attempts = max(1, wait_attempts)
+        self._wait_base = max(5, wait_base_ms)
+        self._wait_max = max(self._wait_base, wait_max_ms)
+
+    async def allocate(self, payload: Mapping[str, Any], *, correlation_id: str) -> CounterResult:
+        try:
+            normalized = self._normalize_payload(payload)
+        except ValueError as exc:
+            self._metrics.record_alloc("validation_error")
+            raise CounterRuntimeError(
+                "COUNTER_VALIDATION_ERROR",
+                "درخواست نامعتبر است؛ سال/جنسیت/مرکز را بررسی کنید.",
+                details=str(exc),
+            ) from exc
+
+        student_hash = _hash_student(normalized["student_id"], salt=self._hash_salt)
+        logger.info(
+            json.dumps(
+                {
+                    "event": "counter.allocate.start",
+                    "correlation_id": correlation_id,
+                    "student": student_hash,
+                    "year": normalized["year"],
+                    "year_code": normalized["year_code"],
+                    "gender": normalized["gender"],
+                    "center": normalized["center"],
+                },
+                ensure_ascii=False,
+            )
+        )
+
+        result = await self._allocate_with_retry(normalized, correlation_id, student_hash)
+        logger.info(
+            json.dumps(
+                {
+                    "event": "counter.allocate.finish",
+                    "correlation_id": correlation_id,
+                    "student": student_hash,
+                    "counter": result.counter,
+                    "status": result.status,
+                },
+                ensure_ascii=False,
+            )
+        )
+        return result
+
+    async def preview(self, payload: Mapping[str, Any]) -> CounterResult:
+        try:
+            year = payload.get("year")
+            gender = _normalize_int_field(payload.get("gender"), field="جنسیت", allowed={0, 1})
+            center = _normalize_int_field(payload.get("center"), field="مرکز", allowed={0, 1, 2})
+            year_code = self._year_provider.code_for(year)
+        except ValueError as exc:
+            raise CounterRuntimeError(
+                "COUNTER_VALIDATION_ERROR",
+                "درخواست نامعتبر است؛ سال/جنسیت/مرکز را بررسی کنید.",
+                details=str(exc),
+            ) from exc
+
+        sequence_key = self._namespaces.counter_sequence(year_code, gender)
+
+        async def _fetch_current() -> int:
+            raw = await self._redis.get(sequence_key)
+            if raw is None:
+                return 0
+            if isinstance(raw, bytes):
+                try:
+                    return int(raw.decode("utf-8"))
+                except ValueError:
+                    return 0
+            try:
+                return int(raw)
+            except ValueError:
+                return 0
+
+        current = await self._executor.call(
+            _fetch_current,
+            op_name="counter_preview",
+        )
+        next_serial = current + 1
+        if next_serial > self._max_serial:
+            self._metrics.record_exhausted(year_code, gender)
+            raise CounterRuntimeError(
+                "COUNTER_EXHAUSTED",
+                "ظرفیت شماره ثبت برای این سال تکمیل شده است.",
+            )
+        counter = f"{year_code}{COUNTER_PREFIX[gender]}{next_serial:04d}"
+        return CounterResult(counter=counter, year_code=year_code, status="preview")
+
+    def _normalize_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        year = payload.get("year")
+        gender = _normalize_int_field(payload.get("gender"), field="جنسیت", allowed={0, 1})
+        center = _normalize_int_field(payload.get("center"), field="مرکز", allowed={0, 1, 2})
+        student_id = _normalize_identifier(payload.get("student_id"))
+        year_code = self._year_provider.code_for(year)
+        normalized_year = normalize_digits(unicodedata.normalize("NFKC", str(year)))
+        normalized_year = _strip_controls(normalized_year).strip()
+        return {
+            "year": normalized_year,
+            "year_code": year_code,
+            "gender": gender,
+            "center": center,
+            "student_id": student_id,
+        }
+
+    async def _allocate_with_retry(
+        self,
+        normalized: Mapping[str, Any],
+        correlation_id: str,
+        student_hash: str,
+    ) -> CounterResult:
+        student_key = self._namespaces.counter_student(normalized["year_code"], normalized["student_id"])
+        sequence_key = self._namespaces.counter_sequence(normalized["year_code"], normalized["gender"])
+
+        async def _run_script() -> str:
+            return await self._redis.eval(
+                _ALLOCATE_SCRIPT,
+                2,
+                student_key,
+                sequence_key,
+                _PENDING_JSON,
+                normalized["year_code"],
+                COUNTER_PREFIX[normalized["gender"]],
+                str(normalized["center"]),
+                str(normalized["gender"]),
+                str(self._max_serial),
+                str(self._placeholder_ttl),
+            )
+
+        backoff = self._wait_base / 1000.0
+        attempts = 0
+        for attempt in range(1, self._wait_attempts + 1):
+            attempts = attempt
+            response = await self._executor.call(
+                _run_script,
+                op_name="counter_allocate",
+                correlation_id=correlation_id,
+            )
+            result = json.loads(response)
+            status = result.get("status")
+            if status == "NEW":
+                counter = result["counter"]
+                if not COUNTER_PATTERN.fullmatch(counter):
+                    raise CounterRuntimeError("COUNTER_STATE_ERROR", "الگوی شماره نامعتبر است.")
+                self._metrics.record_alloc("success")
+                if attempt > 1:
+                    self._metrics.record_retry("counter_allocate", attempts=attempt - 1)
+                return CounterResult(counter=counter, year_code=normalized["year_code"], status="new")
+            if status == "REUSED":
+                counter = result["counter"]
+                if not COUNTER_PATTERN.fullmatch(counter):
+                    raise CounterRuntimeError("COUNTER_STATE_ERROR", "الگوی شماره نامعتبر است.")
+                self._metrics.record_alloc("reused")
+                if attempt > 1:
+                    self._metrics.record_retry("counter_allocate", attempts=attempt - 1)
+                return CounterResult(counter=counter, year_code=normalized["year_code"], status="reused")
+            if status == "PENDING":
+                if attempt == self._wait_attempts:
+                    break
+                self._metrics.record_retry("counter_allocate")
+                await self._executor.sleep(min(backoff, self._wait_max / 1000.0))
+                backoff = min(backoff * 2, self._wait_max / 1000.0)
+                continue
+            if status == "EXHAUSTED":
+                self._metrics.record_exhausted(normalized["year_code"], normalized["gender"])
+                raise CounterRuntimeError(
+                    "COUNTER_EXHAUSTED",
+                    "ظرفیت شماره ثبت برای این سال تکمیل شده است.",
+                )
+            raise CounterRuntimeError(
+                "COUNTER_STATE_ERROR",
+                "پاسخ نامعتبر از زیرساخت شمارنده دریافت شد.",
+                details=json.dumps(result, ensure_ascii=False),
+            )
+
+        raise CounterRuntimeError(
+            "COUNTER_RETRY_EXHAUSTED",
+            "امکان تخصیص شماره ثبت وجود ندارد؛ دوباره تلاش کنید.",
+            details=f"attempts={attempts}",
+        )
+
+
+_PENDING_JSON = json.dumps({"status": "PENDING"})
+
+_ALLOCATE_SCRIPT = """
+-- counter_allocate
+local json = cjson
+local student_key = KEYS[1]
+local sequence_key = KEYS[2]
+local placeholder = ARGV[1]
+local year_code = ARGV[2]
+local prefix = ARGV[3]
+local center = ARGV[4]
+local gender = ARGV[5]
+local seq_max = tonumber(ARGV[6])
+local ttl_ms = tonumber(ARGV[7])
+
+local existing_json = redis.call('GET', student_key)
+if existing_json then
+    local ok, decoded = pcall(json.decode, existing_json)
+    if not ok or decoded == nil then
+        return json.encode({status = 'PENDING'})
+    end
+    if decoded.status == 'PENDING' then
+        return json.encode({status = 'PENDING'})
+    end
+    return json.encode({status = 'REUSED', counter = decoded.counter, serial = decoded.serial})
+end
+
+redis.call('SET', student_key, placeholder, 'PX', ttl_ms)
+local seq = redis.call('INCR', sequence_key)
+if seq > seq_max then
+    redis.call('DEL', student_key)
+    return json.encode({status = 'EXHAUSTED'})
+end
+local serial = string.format('%04d', seq)
+local counter = year_code .. prefix .. serial
+local payload = {status = 'ASSIGNED', counter = counter, center = center, gender = gender, serial = serial, year_code = year_code}
+redis.call('SET', student_key, json.encode(payload))
+return json.encode({status = 'NEW', counter = counter, serial = serial})
+"""
+
+
+__all__ = ["CounterRuntime", "CounterRuntimeError", "CounterResult"]

--- a/src/phase2_counter_service/logging_utils.py
+++ b/src/phase2_counter_service/logging_utils.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import json
 import logging
+from pathlib import Path
 from typing import Any, Dict, Mapping
 
 from .types import HashFunc, LoggerLike
@@ -51,3 +53,13 @@ def make_hash_fn(salt: str) -> HashFunc:
         return digest.hexdigest()
 
     return _hash
+
+
+def atomic_debug_dump(path: Path, payload: Mapping[str, Any]) -> Path:
+    temp_path = path.with_suffix(path.suffix + ".part")
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temp_path, path)
+    return path

--- a/src/phase2_counter_service/runtime_metrics.py
+++ b/src/phase2_counter_service/runtime_metrics.py
@@ -1,0 +1,54 @@
+"""Prometheus metrics for the counter runtime."""
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry, Counter, REGISTRY
+
+
+class CounterRuntimeMetrics:
+    def __init__(self, registry: CollectorRegistry | None = None) -> None:
+        self._registry = registry or REGISTRY
+        self._alloc_total = self._get_or_create_counter(
+            "counter_alloc_total",
+            "Total counter allocation outcomes",
+            ("status",),
+        )
+        self._retry_total = self._get_or_create_counter(
+            "counter_retry_total",
+            "Total retries performed by the counter runtime",
+            ("operation",),
+        )
+        self._exhausted_total = self._get_or_create_counter(
+            "counter_exhausted_total",
+            "Counter sequence exhaustion per year and gender",
+            ("year_code", "gender"),
+        )
+
+    def _get_or_create_counter(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: tuple[str, ...],
+    ) -> Counter:
+        try:
+            return Counter(name, documentation, labelnames, registry=self._registry)
+        except ValueError:
+            collector = self._registry._names_to_collectors.get(name)  # type: ignore[attr-defined]
+            if collector is None:
+                raise
+            return collector  # type: ignore[return-value]
+
+    @property
+    def registry(self) -> CollectorRegistry:
+        return self._registry
+
+    def record_alloc(self, status: str) -> None:
+        self._alloc_total.labels(status=status).inc()
+
+    def record_retry(self, operation: str, attempts: int = 1) -> None:
+        self._retry_total.labels(operation=operation).inc(max(1, attempts))
+
+    def record_exhausted(self, year_code: str, gender: int) -> None:
+        self._exhausted_total.labels(year_code=year_code, gender=str(gender)).inc()
+
+
+__all__ = ["CounterRuntimeMetrics"]

--- a/tests/api/test_counter_errors_fa.py
+++ b/tests/api/test_counter_errors_fa.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import httpx
+
+from src.hardened_api.observability import metrics_registry_guard
+from tests.hardened_api.conftest import build_counter_app, get_debug_context
+
+
+def test_persian_messages() -> None:
+    async def _run() -> None:
+        with metrics_registry_guard():
+            app, redis = build_counter_app(namespace=f"test-{uuid.uuid4()}")
+            transport = httpx.ASGITransport(app=app)
+            try:
+                async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                    response = await client.post(
+                        "/counter/allocate",
+                        json={"year": "", "gender": None, "center": "", "student_id": ""},
+                        headers={
+                            "Authorization": "Bearer TESTTOKEN1234567890",
+                            "Content-Type": "application/json; charset=utf-8",
+                            "Idempotency-Key": "invalid-payload-test",
+                            "X-Request-ID": str(uuid.uuid4()),
+                        },
+                    )
+                body = response.json()
+                assert response.status_code == 400, get_debug_context(app, redis_client=redis)
+                assert body["ok"] is False
+                assert body["code"] == "COUNTER_VALIDATION_ERROR"
+                assert body["message_fa"] == "درخواست نامعتبر است؛ سال/جنسیت/مرکز را بررسی کنید."
+                assert "student" not in body
+            finally:
+                await redis.flushdb()
+                await transport.aclose()
+
+    asyncio.run(_run())

--- a/tests/counter/test_spec_prefix_and_regex.py
+++ b/tests/counter/test_spec_prefix_and_regex.py
@@ -1,0 +1,8 @@
+from src.phase2_counter_service.validation import COUNTER_PATTERN, COUNTER_PREFIX
+
+
+def test_regex_and_prefixes() -> None:
+    assert COUNTER_PREFIX == {0: "373", 1: "357"}
+    assert COUNTER_PATTERN.fullmatch("023731234")
+    assert COUNTER_PATTERN.fullmatch("023571234")
+    assert COUNTER_PATTERN.fullmatch("123670001") is None

--- a/tests/counter/test_year_code_provider.py
+++ b/tests/counter/test_year_code_provider.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.phase2_counter_service.academic_year import AcademicYearProvider
+
+
+def test_year_code_from_provider_no_wall_clock() -> None:
+    forbidden = {"now", "utcnow", "today"}
+    names = set(AcademicYearProvider.code_for.__code__.co_names)
+    assert names.isdisjoint(forbidden)
+    provider = AcademicYearProvider({"1402": "02"})
+    assert provider.code_for("۱۴۰۲") == "02"
+    assert provider.code_for("1403") == "03"
+
+
+@pytest.mark.parametrize("value", [None, "", "abcd", "۱۴"])
+def test_year_code_invalid_inputs(value) -> None:
+    provider = AcademicYearProvider({})
+    with pytest.raises(ValueError):
+        provider.code_for(value)

--- a/tests/hardened_api/test_counter_api.py
+++ b/tests/hardened_api/test_counter_api.py
@@ -1,0 +1,110 @@
+import asyncio
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+from prometheus_client import REGISTRY
+
+from src.hardened_api.observability import metrics_registry_guard
+from tests.hardened_api.conftest import build_counter_app, get_debug_context
+
+
+def _headers(**extra: str) -> dict[str, str]:
+    headers = {
+        "Authorization": "Bearer TESTTOKEN1234567890",
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Request-ID": str(uuid.uuid4()),
+    }
+    headers.update(extra)
+    return headers
+
+
+class _SyncClient:
+    def __init__(self, app) -> None:
+        self._transport = httpx.ASGITransport(app=app)
+
+    def request(self, method: str, url: str, **kwargs):
+        async def _call():
+            async with httpx.AsyncClient(transport=self._transport, base_url="http://testserver") as client:
+                return await client.request(method, url, **kwargs)
+
+        return asyncio.run(_call())
+
+    def get(self, url: str, **kwargs):
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs):
+        return self.request("POST", url, **kwargs)
+
+    def close(self) -> None:
+        asyncio.run(self._transport.aclose())
+
+
+def _build_client() -> tuple[_SyncClient, Any]:
+    app, redis_client = build_counter_app()
+    return _SyncClient(app), redis_client
+
+
+@pytest.fixture()
+def client():
+    with metrics_registry_guard():
+        test_client, redis_client = _build_client()
+        try:
+            yield test_client, redis_client
+        finally:
+            asyncio.run(redis_client.flushdb())
+            test_client.close()
+
+
+def test_counter_allocate_success(client) -> None:
+    test_client, _ = client
+    payload = {"year": "1402", "gender": 1, "center": 1, "student_id": "student-001"}
+    headers = _headers(**{"Idempotency-Key": "COUNTERTESTKEY001"})
+    response = test_client.post("/counter/allocate", json=payload, headers=headers)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["ok"] is True
+    assert data["counter"].startswith("02")
+    assert data["year_code"] == "02"
+    cached = test_client.post("/counter/allocate", json=payload, headers=headers)
+    assert cached.status_code == 200
+    assert cached.json()["counter"] == data["counter"]
+
+
+def test_counter_validation_error_is_persian(client) -> None:
+    test_client, redis_client = client
+    response = test_client.post(
+        "/counter/allocate",
+        json={"year": "abcd", "gender": 5, "center": 9, "student_id": ""},
+        headers=_headers(),
+    )
+    body = response.json()
+    assert response.status_code == 400, get_debug_context(redis_client=redis_client)
+    assert body["ok"] is False
+    assert body["code"] == "COUNTER_VALIDATION_ERROR"
+    assert "درخواست نامعتبر" in body["message_fa"]
+
+
+def test_counter_preview_success(client) -> None:
+    test_client, _ = client
+    response = test_client.get(
+        "/counter/preview",
+        params={"year": "1402", "gender": 0, "center": 1},
+        headers=_headers(),
+    )
+    data = response.json()
+    assert response.status_code == 200
+    assert data["ok"] is True
+    assert data["counter"].startswith("02")
+
+
+def test_counter_metrics_increment(client) -> None:
+    test_client, _ = client
+    payload = {"year": "1402", "gender": 0, "center": 1, "student_id": "student-xyz"}
+    headers = _headers(**{"Idempotency-Key": "COUNTERTESTKEY002"})
+    test_client.post("/counter/allocate", json=payload, headers=headers)
+    collected = {metric.name: metric for metric in REGISTRY.collect() if metric.name.startswith("counter_")}
+    assert "counter_alloc" in collected
+    alloc_samples = [s for s in collected["counter_alloc"].samples if s.name.endswith("_total")]
+    assert any(sample.labels.get("status") == "success" and sample.value >= 1 for sample in alloc_samples)

--- a/tests/hygiene/test_config_guard.py
+++ b/tests/hygiene/test_config_guard.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from src.hardened_api.middleware import (
+    ensure_rate_limit_config_restored,
+    RateLimitConfig,
+    RateLimitRule,
+    rate_limit_config_guard,
+    restore_rate_limit_config,
+    snapshot_rate_limit_config,
+)
+
+
+def test_rate_limit_config_snapshot() -> None:
+    config = RateLimitConfig(
+        default_rule=RateLimitRule(requests=10, window_seconds=1.0),
+        per_route={"/counter/allocate": RateLimitRule(requests=5, window_seconds=1.0)},
+        fail_open=False,
+    )
+    snapshot = snapshot_rate_limit_config(config)
+
+    config.default_rule.requests = 20
+    with pytest.raises(AssertionError):
+        ensure_rate_limit_config_restored(config, snapshot, context="unit-test")
+
+    restore_rate_limit_config(config, snapshot)
+    ensure_rate_limit_config_restored(config, snapshot)
+
+    with rate_limit_config_guard(config) as guarded:
+        guarded.fail_open = True
+
+    assert config.fail_open is False

--- a/tests/hygiene/test_state_cleanup.py
+++ b/tests/hygiene/test_state_cleanup.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+
+from src.hardened_api.observability import get_metric, metrics_registry_guard
+from tests.hardened_api.conftest import FakeRedis
+
+
+def test_redis_and_registry_reset() -> None:
+    async def _run() -> None:
+        redis = FakeRedis()
+        await redis.set("test:key", "value")
+        assert await redis.get("test:key") is not None
+        await redis.flushdb()
+        assert await redis.get("test:key") is None
+
+        with metrics_registry_guard():
+            metric = get_metric("redis_retry_attempts_total")
+            metric.labels(op="guard-test", outcome="success").inc()
+            samples = metric.collect()[0].samples
+            recorded = [s.value for s in samples if s.labels.get("op") == "guard-test"]
+            assert recorded and recorded[0] == 1.0
+
+        post_samples = metric.collect()[0].samples
+        after = [s.value for s in post_samples if s.labels.get("op") == "guard-test"]
+        assert not after or after[0] == 0.0
+
+    asyncio.run(_run())

--- a/tests/integration/test_export_readiness.py
+++ b/tests/integration/test_export_readiness.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+
+from src.hardened_api.redis_support import RedisExecutor, RedisNamespaces, RedisRetryConfig
+from src.phase2_counter_service.academic_year import AcademicYearProvider
+from src.phase2_counter_service.counter_runtime import CounterRuntime
+from src.phase2_counter_service.runtime_metrics import CounterRuntimeMetrics
+from src.phase2_counter_service.validation import COUNTER_PATTERN, COUNTER_PREFIX
+from tests.hardened_api.conftest import FakeRedis
+
+
+def test_counter_shape_matches_export_needs() -> None:
+    async def _run() -> None:
+        redis = FakeRedis()
+        executor = RedisExecutor(
+            config=RedisRetryConfig(attempts=2, base_delay=0.0, max_delay=0.0, jitter=0.0),
+            namespace="export-readiness",
+        )
+        runtime = CounterRuntime(
+            redis=redis,
+            namespaces=RedisNamespaces("export"),
+            executor=executor,
+            metrics=CounterRuntimeMetrics(),
+            year_provider=AcademicYearProvider({"1402": "02"}),
+            hash_salt="export",
+        )
+
+        result = await runtime.allocate(
+            {"year": "1402", "gender": 0, "center": 1, "student_id": "EXPORT-001"},
+            correlation_id="export",
+        )
+        assert COUNTER_PATTERN.fullmatch(result.counter)
+        assert result.year_code == "02"
+        assert result.counter.startswith("02" + COUNTER_PREFIX[0])
+
+        preview = await runtime.preview({"year": "1402", "gender": "۰", "center": "۱"})
+        assert COUNTER_PATTERN.fullmatch(preview.counter)
+
+        await redis.flushdb()
+
+    asyncio.run(_run())

--- a/tests/io/test_atomic_debug_dump.py
+++ b/tests/io/test_atomic_debug_dump.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.phase2_counter_service.logging_utils import atomic_debug_dump
+
+
+def test_atomic_write(tmp_path: Path) -> None:
+    destination = tmp_path / "debug.json"
+    payload = {"status": "ok", "counter": "023730001"}
+    written = atomic_debug_dump(destination, payload)
+    assert written.exists()
+    assert not destination.with_suffix(".json.part").exists()
+    data = json.loads(destination.read_text("utf-8"))
+    assert data == payload

--- a/tests/logging/test_masking.py
+++ b/tests/logging/test_masking.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from hashlib import blake2s
+
+from src.hardened_api.redis_support import RedisExecutor, RedisNamespaces, RedisRetryConfig
+from src.phase2_counter_service.academic_year import AcademicYearProvider
+from src.phase2_counter_service.counter_runtime import CounterRuntime
+from src.phase2_counter_service.runtime_metrics import CounterRuntimeMetrics
+
+
+class _SimpleRedis:
+    async def eval(self, script: str, numkeys: int, *args):
+        argv = args[numkeys:]
+        year_code = argv[1]
+        prefix = argv[2]
+        counter = f"{year_code}{prefix}0001"
+        return json.dumps({"status": "NEW", "counter": counter, "serial": "0001"})
+
+    async def get(self, name: str):
+        return None
+
+
+def test_no_raw_pii_in_logs(caplog) -> None:
+    async def _run() -> None:
+        executor = RedisExecutor(
+            config=RedisRetryConfig(attempts=1, base_delay=0.0, max_delay=0.0, jitter=0.0),
+            namespace="log-mask",
+        )
+        runtime = CounterRuntime(
+            redis=_SimpleRedis(),
+            namespaces=RedisNamespaces("masking"),
+            executor=executor,
+            metrics=CounterRuntimeMetrics(),
+            year_provider=AcademicYearProvider({"1402": "02"}),
+            hash_salt="mask",
+        )
+        payload = {"year": "1402", "gender": 1, "center": 0, "student_id": "MASK-۹۹۹۹"}
+        with caplog.at_level(logging.INFO):
+            await runtime.allocate(payload, correlation_id="masking")
+
+        hashed = blake2s(key=b"mask", digest_size=16)
+        hashed.update("MASK-۹۹۹۹".encode("utf-8"))
+        digest = hashed.hexdigest()
+        assert digest in caplog.text
+        assert "MASK-۹۹۹۹" not in caplog.text
+
+    asyncio.run(_run())

--- a/tests/mw/test_order_counter.py
+++ b/tests/mw/test_order_counter.py
@@ -1,0 +1,38 @@
+import uuid
+
+import pytest
+
+from src.hardened_api.api import APISettings, create_app
+from src.hardened_api.auth_repository import APIKeyRecord, InMemoryAPIKeyRepository
+from src.hardened_api.middleware import AuthConfig
+from src.hardened_api.observability import hash_national_id, metrics_registry_guard
+from tests.hardened_api.conftest import FakeAllocator, FakeRedis, verify_middleware_order
+
+
+def _build_app():
+    redis_client = FakeRedis()
+    allocator = FakeAllocator()
+    salt = "testsalt"
+    raw_key = "STATICKEY1234567890"
+    repo = InMemoryAPIKeyRepository([APIKeyRecord(name="fixture", key_hash=hash_national_id(raw_key, salt=salt))])
+    auth_config = AuthConfig(
+        bearer_secret="secret-key",
+        api_key_salt=salt,
+        accepted_audience={"alloc"},
+        accepted_issuers={"issuer"},
+        allow_plain_tokens={"TESTTOKEN1234567890"},
+        api_key_repository=repo,
+    )
+    settings = APISettings(redis_namespace=f"test-{uuid.uuid4()}")
+    return create_app(allocator=allocator, settings=settings, auth_config=auth_config, redis_client=redis_client)
+
+
+@pytest.fixture()
+def counter_app():
+    with metrics_registry_guard():
+        app = _build_app()
+        yield app
+
+
+def test_middleware_order_counter_post(counter_app):
+    verify_middleware_order(counter_app)

--- a/tests/normalize/test_phase1_rules_ci.py
+++ b/tests/normalize/test_phase1_rules_ci.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.normalize import normalize_gender, normalize_reg_center, normalize_reg_status
+from src.phase6_import_to_sabt.sanitization import sanitize_phone, sanitize_text
+
+
+def test_text_and_phone_rules() -> None:
+    text = sanitize_text("\u200cحكيم")
+    assert text == "حکیم"
+    phone = sanitize_phone("۰۹۱۲۳۴۵۶۷۸۹")
+    assert phone == "09123456789"
+
+
+@pytest.mark.parametrize("value", [None, 5, "ناشناخته"])
+def test_gender_rules(value) -> None:
+    with pytest.raises(ValueError):
+        normalize_gender(value)
+
+
+@pytest.mark.parametrize("value", [None, 5, "خارج"])
+def test_center_rules(value) -> None:
+    with pytest.raises(ValueError):
+        normalize_reg_center(value)
+
+
+@pytest.mark.parametrize("value", [None, 7, "بی‌اثر"])
+def test_status_rules(value) -> None:
+    with pytest.raises(ValueError):
+        normalize_reg_status(value)

--- a/tests/obs/test_counter_metrics_logs.py
+++ b/tests/obs/test_counter_metrics_logs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from hashlib import blake2s
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+from src.hardened_api.redis_support import RedisExecutor, RedisNamespaces, RedisRetryConfig
+from src.phase2_counter_service.academic_year import AcademicYearProvider
+from src.phase2_counter_service.counter_runtime import CounterRuntime, CounterRuntimeError
+from src.phase2_counter_service.runtime_metrics import CounterRuntimeMetrics
+
+
+class _ScriptStubRedis:
+    def __init__(self) -> None:
+        self._calls = 0
+
+    async def eval(self, script: str, numkeys: int, *args):
+        keys = args[:numkeys]
+        argv = args[numkeys:]
+        self._calls += 1
+        if self._calls == 1:
+            return json.dumps({"status": "PENDING"})
+        year_code = argv[1]
+        prefix = argv[2]
+        counter = f"{year_code}{prefix}0001"
+        return json.dumps({"status": "NEW", "counter": counter, "serial": "0001"})
+
+    async def get(self, name: str):
+        return None
+
+
+def test_retry_exhaustion_metrics_and_masking(caplog) -> None:
+    async def _run() -> None:
+        registry = CollectorRegistry()
+        metrics = CounterRuntimeMetrics(registry)
+        namespaces = RedisNamespaces("test-counter-metrics")
+        retry_config = RedisRetryConfig(attempts=2, base_delay=0.0, max_delay=0.0, jitter=0.0)
+        sleeps: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        executor = RedisExecutor(
+            config=retry_config,
+            namespace="test-counter-metrics",
+            rng=lambda: 0.0,
+            monotonic=lambda: 0.0,
+            sleep=fake_sleep,
+        )
+        runtime = CounterRuntime(
+            redis=_ScriptStubRedis(),
+            namespaces=namespaces,
+            executor=executor,
+            metrics=metrics,
+            year_provider=AcademicYearProvider({"1402": "02"}),
+            hash_salt="pepper",
+            wait_attempts=2,
+            wait_base_ms=10,
+            wait_max_ms=20,
+        )
+
+        payload = {"year": "1402", "gender": 0, "center": 1, "student_id": "STU-۹۸۷"}
+        with caplog.at_level(logging.INFO):
+            result = await runtime.allocate(payload, correlation_id="corr-1")
+
+        assert result.counter.startswith("02")
+        hashed = blake2s(key=b"pepper", digest_size=16)
+        hashed.update("STU-۹۸۷".encode("utf-8"))
+        digest = hashed.hexdigest()
+        assert digest in caplog.text
+        assert "STU-۹۸۷" not in caplog.text
+        assert sleeps == [0.01]
+
+        retry_value = registry.get_sample_value("counter_retry_total", {"operation": "counter_allocate"})
+        assert retry_value == 2.0
+
+        runtime._max_serial = 0  # type: ignore[attr-defined]
+        with pytest.raises(CounterRuntimeError) as excinfo:
+            await runtime.preview({"year": "1402", "gender": "۰", "center": "۱"})
+        assert excinfo.value.code == "COUNTER_EXHAUSTED"
+
+        exhausted_value = registry.get_sample_value("counter_exhausted_total", {"year_code": "02", "gender": "0"})
+        assert exhausted_value == 1.0
+
+    asyncio.run(_run())

--- a/tests/obs/test_metrics_counter.py
+++ b/tests/obs/test_metrics_counter.py
@@ -1,0 +1,27 @@
+from prometheus_client import CollectorRegistry
+
+from src.phase2_counter_service.runtime_metrics import CounterRuntimeMetrics
+
+
+def test_retry_and_exhaustion_metrics() -> None:
+    registry = CollectorRegistry()
+    metrics = CounterRuntimeMetrics(registry)
+    metrics.record_alloc("success")
+    metrics.record_retry("counter_allocate", attempts=3)
+    metrics.record_exhausted("02", 1)
+
+    collected = {metric.name: metric for metric in registry.collect()}
+    alloc_samples = collected["counter_alloc"].samples
+    assert any(sample.labels.get("status") == "success" and sample.value == 1.0 for sample in alloc_samples if sample.name.endswith("_total"))
+    retry_samples = collected["counter_retry"].samples
+    assert any(
+        sample.labels.get("operation") == "counter_allocate" and sample.value == 3.0
+        for sample in retry_samples
+        if sample.name.endswith("_total")
+    )
+    exhausted_samples = collected["counter_exhausted"].samples
+    assert any(
+        sample.labels.get("year_code") == "02" and sample.labels.get("gender") == "1" and sample.value == 1.0
+        for sample in exhausted_samples
+        if sample.name.endswith("_total")
+    )

--- a/tests/perf/test_counter_p95_ci.py
+++ b/tests/perf/test_counter_p95_ci.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+from src.hardened_api.redis_support import RedisExecutor, RedisNamespaces, RedisRetryConfig
+from src.phase2_counter_service.academic_year import AcademicYearProvider
+from src.phase2_counter_service.counter_runtime import CounterRuntime
+from src.phase2_counter_service.runtime_metrics import CounterRuntimeMetrics
+
+
+class _FastRedis:
+    async def eval(self, script: str, numkeys: int, *args):
+        argv = args[numkeys:]
+        year_code = argv[1]
+        prefix = argv[2]
+        serial = "0001"
+        counter = f"{year_code}{prefix}{serial}"
+        return json.dumps({"status": "NEW", "counter": counter, "serial": serial})
+
+    async def get(self, name: str):
+        return b"0"
+
+
+def test_p95_under_budget() -> None:
+    async def _run() -> None:
+        async def no_sleep(_: float) -> None:
+            return None
+
+        executor = RedisExecutor(
+            config=RedisRetryConfig(attempts=1, base_delay=0.0, max_delay=0.0, jitter=0.0),
+            namespace="counter-perf",
+            rng=lambda: 0.0,
+            monotonic=time.perf_counter,
+            sleep=no_sleep,
+        )
+        runtime = CounterRuntime(
+            redis=_FastRedis(),
+            namespaces=RedisNamespaces("perf-counter"),
+            executor=executor,
+            metrics=CounterRuntimeMetrics(),
+            year_provider=AcademicYearProvider({"1402": "02"}),
+            hash_salt="perf",
+            wait_attempts=1,
+        )
+
+        durations: list[float] = []
+        for idx in range(50):
+            start = time.perf_counter()
+            await runtime.allocate(
+                {"year": "1402", "gender": 0, "center": 1, "student_id": f"perf-{idx}"},
+                correlation_id=f"perf-{idx}",
+            )
+            durations.append(time.perf_counter() - start)
+
+        durations.sort()
+        cutoff_index = int(len(durations) * 0.95) - 1
+        cutoff_index = max(cutoff_index, 0)
+        p95 = durations[cutoff_index]
+        assert p95 <= 0.12
+
+    asyncio.run(_run())

--- a/tests/perf/test_counter_p95_real.py
+++ b/tests/perf/test_counter_p95_real.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+import uuid
+
+import httpx
+import pytest
+from redis.asyncio import Redis
+
+from src.hardened_api.middleware import (
+    ensure_rate_limit_config_restored,
+    restore_rate_limit_config,
+    snapshot_rate_limit_config,
+)
+from tests.hardened_api.conftest import build_counter_app, get_debug_context, verify_middleware_order
+from tests.hardened_api.redis_launcher import RedisLaunchSkipped, launch_redis_server
+
+
+@pytest.mark.performance
+def test_p95_under_budget_real_redis() -> None:
+    async def _run() -> None:
+        try:
+            with launch_redis_server() as runtime:
+                redis_client = Redis.from_url(runtime.url, encoding="utf-8", decode_responses=False)
+                namespace = f"perf-real:{uuid.uuid4()}"
+                await redis_client.flushdb()
+                app, _ = build_counter_app(
+                    namespace=namespace,
+                    metrics_ip_allowlist=["testserver", "127.0.0.1"],
+                    redis_client=redis_client,
+                    settings_overrides={
+                        "redis_url": runtime.url,
+                        "redis_namespace": namespace,
+                        "counter_year_map": {"1402": "02"},
+                        "rate_limit_allocations": 200,
+                        "rate_limit_window": 1.0,
+                    },
+                )
+                verify_middleware_order(app)
+                config = app.state.middleware_state.rate_limit_config  # type: ignore[attr-defined]
+                snapshot = snapshot_rate_limit_config(config)
+                transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+                headers = {
+                    "Content-Type": "application/json; charset=utf-8",
+                    "X-API-Key": "STATICKEY1234567890",
+                }
+                durations: list[float] = []
+                warmup = 5
+                samples = 40
+                try:
+                    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                        setattr(client, "app", app)
+                        for idx in range(warmup + samples):
+                            payload = {
+                                "year": "1402",
+                                "gender": 1,
+                                "center": 1,
+                                "student_id": f"perf-real-{idx}",
+                            }
+                            headers["Idempotency-Key"] = f"PERFKEY{idx:08d}AB"
+                            start = time.perf_counter()
+                            response = await client.post(
+                                "/counter/allocate",
+                                headers=headers,
+                                json=payload,
+                            )
+                            assert response.status_code == 200, get_debug_context(client.app)
+                            durations.append(time.perf_counter() - start)
+                finally:
+                    try:
+                        ensure_rate_limit_config_restored(
+                            config,
+                            snapshot,
+                            context="test_p95_under_budget_real_redis",
+                        )
+                    finally:
+                        restore_rate_limit_config(config, snapshot)
+                    await transport.aclose()
+                    await redis_client.flushdb()
+                    await redis_client.aclose()
+                measured = durations[warmup:]
+                measured.sort()
+                index = max(0, math.ceil(len(measured) * 0.95) - 1)
+                p95 = measured[index] if measured else 0.0
+                assert p95 <= 0.12, f"p95 latency {p95:.6f}s exceeded budget"
+        except RedisLaunchSkipped as exc:
+            pytest.fail(f"Redis server unavailable: {exc}")
+
+    asyncio.run(_run())

--- a/tests/security/test_metrics_allowlist.py
+++ b/tests/security/test_metrics_allowlist.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import httpx
+
+from src.hardened_api.observability import get_metric, metrics_registry_guard
+from tests.hardened_api.conftest import build_counter_app
+
+
+def test_metrics_success_path_allowed() -> None:
+    async def _run() -> None:
+        with metrics_registry_guard():
+            app, redis_client = build_counter_app(
+                namespace=f"metrics-allow-{uuid.uuid4()}",
+                metrics_token="secret-token",
+                metrics_ip_allowlist=["testserver", "127.0.0.1"],
+            )
+            transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+            headers = {
+                "Authorization": "Bearer secret-token",
+                "X-API-Key": "STATICKEY1234567890",
+            }
+            try:
+                async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                    response = await client.get("/metrics", headers=headers)
+                    assert response.status_code == 200, response.text
+                    payload = response.text
+                    assert "counter_alloc_total" in payload
+                scrape_metric = get_metric("metrics_scrape_total")
+                samples = [
+                    sample
+                    for metric in scrape_metric.collect()
+                    for sample in metric.samples
+                    if sample.name.endswith("_total")
+                ]
+                assert any(
+                    sample.labels.get("outcome") == "success" and sample.value >= 1
+                    for sample in samples
+                )
+                assert not any(sample.labels.get("outcome") == "token_denied" for sample in samples)
+            finally:
+                await redis_client.flushdb()
+                await transport.aclose()
+
+    asyncio.run(_run())

--- a/tests/security/test_metrics_guard.py
+++ b/tests/security/test_metrics_guard.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import httpx
+
+from src.hardened_api.observability import metrics_registry_guard
+from tests.hardened_api.conftest import build_counter_app
+
+
+def test_metrics_requires_token() -> None:
+    async def _run() -> None:
+        with metrics_registry_guard():
+            app, redis = build_counter_app(
+                namespace=f"test-{uuid.uuid4()}",
+                metrics_token="secret-token",
+                metrics_ip_allowlist=["testserver", "127.0.0.1"],
+            )
+            transport = httpx.ASGITransport(app=app)
+            try:
+                async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                    unauthorized = await client.get("/metrics")
+                    assert unauthorized.status_code == 401
+                    denied = await client.get(
+                        "/metrics",
+                        headers={"Authorization": "Bearer secret-token"},
+                    )
+                    assert denied.status_code == 401
+            finally:
+                await redis.flushdb()
+                await transport.aclose()
+
+    asyncio.run(_run())

--- a/tests/text/test_formula_guard.py
+++ b/tests/text/test_formula_guard.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from src.phase6_import_to_sabt.sanitization import guard_formula
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("=SUM(A1:A2)", "'=SUM(A1:A2)"),
+        ("+VALUE", "'+VALUE"),
+        ("12345", "12345"),
+    ],
+)
+def test_leading_apostrophe(value: str, expected: str) -> None:
+    assert guard_formula(value) == expected

--- a/tests/text/test_normalize_fa.py
+++ b/tests/text/test_normalize_fa.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from src.core.normalize import normalize_digits
+from src.phase6_import_to_sabt.sanitization import sanitize_text
+
+
+def test_nfkc_digitfold_unify() -> None:
+    raw = "\u200cكلاس ۱۲۳٤"
+    sanitized = sanitize_text(raw)
+    digits = normalize_digits(sanitized)
+    assert sanitized.startswith("کلاس")
+    assert digits.endswith("1234")

--- a/tests/time/test_clock_freeze.py
+++ b/tests/time/test_clock_freeze.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from src.hardened_api.redis_support import RedisExecutor, RedisNamespaces, RedisRetryConfig
+from src.phase2_counter_service.academic_year import AcademicYearProvider
+from src.phase2_counter_service.counter_runtime import CounterRuntime
+from src.phase2_counter_service.runtime_metrics import CounterRuntimeMetrics
+
+
+class _DeterministicClock:
+    def __init__(self) -> None:
+        self._now = 1_000.0
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+    def monotonic(self) -> float:
+        return self._now
+
+
+class _PendingRedis:
+    def __init__(self) -> None:
+        self._invocations: list[int] = []
+        self._called = 0
+
+    async def eval(self, script: str, numkeys: int, *args):
+        argv = args[numkeys:]
+        ttl_ms = int(argv[-1])
+        self._invocations.append(ttl_ms)
+        self._called += 1
+        if self._called == 1:
+            return json.dumps({"status": "PENDING"})
+        year_code = argv[1]
+        prefix = argv[2]
+        counter = f"{year_code}{prefix}0001"
+        return json.dumps({"status": "NEW", "counter": counter, "serial": "0001"})
+
+    async def get(self, name: str):
+        return None
+
+
+def test_backoff_and_ttl_without_wall_clock() -> None:
+    async def _run() -> None:
+        clock = _DeterministicClock()
+        sleeps: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+            clock.advance(delay)
+
+        executor = RedisExecutor(
+            config=RedisRetryConfig(attempts=2, base_delay=0.0, max_delay=0.0, jitter=0.0),
+            namespace="counter-clock-test",
+            rng=lambda: 0.0,
+            monotonic=clock.monotonic,
+            sleep=fake_sleep,
+        )
+        metrics = CounterRuntimeMetrics()
+        redis = _PendingRedis()
+        runtime = CounterRuntime(
+            redis=redis,
+            namespaces=RedisNamespaces("test-clock"),
+            executor=executor,
+            metrics=metrics,
+            year_provider=AcademicYearProvider({"1402": "02"}),
+            hash_salt="clock-test",
+            wait_attempts=2,
+            wait_base_ms=10,
+            wait_max_ms=10,
+        )
+
+        result = await runtime.allocate(
+            {"year": "1402", "gender": 1, "center": 1, "student_id": "clock-01"},
+            correlation_id="clock",
+        )
+        assert result.counter.startswith("02")
+        assert sleeps == [0.01]
+        assert redis._invocations[-1] == runtime._placeholder_ttl  # type: ignore[attr-defined]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- extend the metrics endpoint to emit scrape outcome counters and expose a dedicated handler for allowlisted clients
- harden the Redis Lua allocator script for real Redis by using safe decode/encode paths and allow the counter test harness to inject custom redis clients
- add security and performance tests covering an allowlisted metrics scrape and a real-Redis p95 benchmark harness

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/counter tests/api/test_counter_errors_fa.py tests/obs/test_metrics_counter.py tests/obs/test_counter_metrics_logs.py tests/security/test_metrics_guard.py tests/security/test_metrics_allowlist.py tests/perf/test_counter_p95_ci.py tests/perf/test_counter_p95_real.py tests/perf/test_memory_budget.py tests/hygiene/test_state_cleanup.py tests/hygiene/test_config_guard.py tests/time/test_clock_freeze.py tests/integration/test_export_readiness.py tests/io/test_atomic_debug_dump.py tests/logging/test_masking.py tests/normalize/test_phase1_rules_ci.py tests/text tests/hardened_api/test_counter_api.py tests/mw/test_order_counter.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d83e8c855c83219108d5b3af6f4929