### PR TITLE
Harden automation audit surfaces and restructure tests

### DIFF
--- a/automation_audit/__init__.py
+++ b/automation_audit/__init__.py
@@ -1,0 +1,3 @@
+"""automation_audit package providing auditing services."""
+
+from .cli import main as cli_main  # noqa: F401

--- a/automation_audit/api.py
+++ b/automation_audit/api.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, Optional, Set
+
+import redis
+from fastapi import FastAPI, HTTPException, Request, Response, status
+from fastapi.routing import APIRouter
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+from .auth import AuthConfig, AuthMiddleware
+from .idem import IdempotencyStore
+from .logging import log_json
+from .metrics import Metrics, build_metrics, render_metrics
+from .ratelimit import RateLimitConfig, RateLimiter
+from .retry import RetryConfig, retry_async
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, limiter: RateLimiter, token_provider: Callable[[Request], str]) -> None:
+        super().__init__(app)
+        self.limiter = limiter
+        self.token_provider = token_provider
+
+    async def dispatch(self, request: Request, call_next):  # pragma: no cover - integration tested
+        token = self.token_provider(request)
+        if not self.limiter.allow(token):
+            return JSONResponse(
+                {"detail": "خطای نرخ‌دهی؛ بعداً تلاش کنید."}, status_code=status.HTTP_429_TOO_MANY_REQUESTS
+            )
+        return await call_next(request)
+
+
+class IdempotencyMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, store: IdempotencyStore):
+        super().__init__(app)
+        self.store = store
+
+    async def dispatch(self, request: Request, call_next):  # pragma: no cover - integration tested
+        if request.method.upper() in {"POST", "PUT"}:
+            key = request.headers.get("idempotency-key")
+            if not key or not (8 <= len(key) <= 64):
+                return JSONResponse(
+                    {"detail": "کلید تکرار نامعتبر است؛ باید ۸ تا ۶۴ نویسهٔ مجاز باشد."}, status_code=status.HTTP_400_BAD_REQUEST
+                )
+            if not self.store.put_if_absent(key, {"method": request.method, "path": request.url.path}):
+                return JSONResponse({"detail": "درخواست تکراری است."}, status_code=status.HTTP_409_CONFLICT)
+        return await call_next(request)
+
+
+def _extract_bearer_token(header: str | None) -> str | None:
+    if not header:
+        return None
+    header = header.strip()
+    if header.lower().startswith("bearer "):
+        return header.split(" ", 1)[1].strip()
+    return None
+
+
+def _client_ip(request: Request) -> str | None:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",", 1)[0].strip()
+    if request.client:
+        return request.client.host
+    return None
+
+
+def create_app(
+    *,
+    redis_client: Optional[redis.Redis] = None,
+    metrics: Optional[Metrics] = None,
+    auth_tokens: Optional[list[str]] = None,
+    rate_limit_config: Optional[RateLimitConfig] = None,
+    metrics_token: str = "metrics-token",
+    metrics_allowed_ips: Optional[Set[str]] = None,
+) -> FastAPI:
+    redis_client = redis_client or redis.Redis(host="localhost", port=6379, decode_responses=True)
+    metrics = metrics or build_metrics()
+    auth_tokens = auth_tokens or ["local-token"]
+    rate_limit_config = rate_limit_config or RateLimitConfig()
+    allowed_metrics_ips = set(metrics_allowed_ips or set())
+    combined_tokens = list({*auth_tokens, metrics_token})
+
+    limiter = RateLimiter(redis_client, rate_limit_config)
+    idem_store = IdempotencyStore(redis_client)
+
+    app = FastAPI()
+
+    app.add_middleware(AuthMiddleware, config=AuthConfig(combined_tokens))
+    app.add_middleware(IdempotencyMiddleware, store=idem_store)
+    app.add_middleware(
+        RateLimitMiddleware,
+        limiter=limiter,
+        token_provider=lambda request: request.headers.get("x-ratelimit-token", request.client.host if request.client else "anon"),
+    )
+
+    router = APIRouter()
+
+    @router.post("/audit")
+    async def run_audit(request: Request) -> dict[str, str]:
+        metrics.audit_runs.inc()
+
+        async def perform():
+            await asyncio.sleep(0)
+            return {"status": "ok"}
+
+        try:
+            result = await retry_async(lambda: perform(), config=RetryConfig(), metrics=metrics)
+        except Exception as exc:  # pragma: no cover - error path
+            metrics.audit_failures.inc()
+            raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail="خطای داخلی سامانه.") from exc
+        log_json("audit_completed", status="ok")
+        return result
+
+    @router.get("/metrics")
+    async def get_metrics(request: Request) -> Response:
+        token = _extract_bearer_token(request.headers.get("authorization"))
+        ip = _client_ip(request)
+        if token != metrics_token or (allowed_metrics_ips and (ip not in allowed_metrics_ips)):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="دسترسی به متریک‌ها مجاز نیست.")
+        data = render_metrics(metrics)
+        return Response(content=data, media_type="text/plain; version=0.0.4")
+
+    app.include_router(router)
+    return app

--- a/automation_audit/auth.py
+++ b/automation_audit/auth.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from fastapi import HTTPException, Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+
+class AuthConfig:
+    def __init__(self, tokens: Iterable[str], *, ip_allowlist: Optional[Iterable[str]] = None) -> None:
+        self.tokens = {token for token in tokens if token}
+        self.ip_allowlist = {ip for ip in ip_allowlist or []}
+
+    def is_allowed(self, request: Request) -> bool:
+        client_host = request.client.host if request.client else None
+        if self.ip_allowlist and client_host not in self.ip_allowlist:
+            return False
+        header = request.headers.get("authorization", "")
+        if header.lower().startswith("bearer "):
+            token = header.split(" ", 1)[1]
+            return token in self.tokens
+        return False
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, config: AuthConfig):
+        super().__init__(app)
+        self.config = config
+
+    async def dispatch(self, request: Request, call_next):  # pragma: no cover - integration tested
+        if not self.config.is_allowed(request):
+            return JSONResponse({"detail": "دسترسی مجاز نیست."}, status_code=status.HTTP_401_UNAUTHORIZED)
+        return await call_next(request)

--- a/automation_audit/ci_scan.py
+++ b/automation_audit/ci_scan.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .normalize import normalize_text
+
+CI_PATTERNS = {
+    "github": re.compile(r"\.github/workflows/.+\.yml$"),
+    "gitlab": re.compile(r"\.gitlab-ci\.yml$"),
+    "azure": re.compile(r"azure-pipelines\.yml$"),
+    "jenkins": re.compile(r"Jenkinsfile$"),
+}
+
+INSTALL_RE = re.compile(r"install|pip|poetry", re.IGNORECASE)
+TEST_RE = re.compile(r"test|pytest|unittest", re.IGNORECASE)
+ARTIFACT_RE = re.compile(r"artifact|upload", re.IGNORECASE)
+ENV_VARS = {"PYTHONWARNINGS", "HEADLESS", "CI"}
+
+
+def iter_ci_files(root: Path) -> Iterable[Path]:
+    root = root or Path.cwd()
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        text = str(rel)
+        if any(pattern.search(text) for pattern in CI_PATTERNS.values()):
+            yield path
+
+
+def analyze_ci_file(path: Path) -> Dict[str, List[str]]:
+    env_found: set[str] = set()
+    steps: set[str] = set()
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for raw_line in handle:
+            line = normalize_text(raw_line)
+            for var in ENV_VARS:
+                if var in line:
+                    env_found.add(var)
+            if INSTALL_RE.search(line):
+                steps.add("install")
+            if TEST_RE.search(line):
+                steps.add("test")
+            if ARTIFACT_RE.search(line):
+                steps.add("artifact")
+    return {"env": sorted(env_found), "steps": sorted(steps)}

--- a/automation_audit/cli.py
+++ b/automation_audit/cli.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List
+
+from .ci_scan import analyze_ci_file, iter_ci_files
+from .exporter import AuditFinding, CSVSafeWriter, render_markdown
+from .fs_atomic import atomic_writer
+from .logging import configure_logging, log_json, set_correlation_id
+from .metrics import build_metrics
+from .retry import RetryConfig, retry_async
+
+DEFAULT_SEED = "automation_audit_seed"
+HOOK_DIRECTORIES = (Path(".git/hooks"), Path(".husky"))
+SCRIPT_DIRECTORIES = (Path("scripts"), Path("tools"))
+CONFIG_FILES = (
+    Path(".pre-commit-config.yaml"),
+    Path("package.json"),
+    Path("Makefile"),
+    Path("tox.ini"),
+    Path("noxfile.py"),
+)
+CSV_HEADERS = ["automation", "status", "provider", "severity", "message", "remediation"]
+
+
+@dataclass
+class AuditResult:
+    correlation_id: str
+    findings: List[AuditFinding] = field(default_factory=list)
+    provider_counts: Dict[str, int] = field(default_factory=dict)
+    severity_counts: Dict[str, int] = field(default_factory=dict)
+    status_counts: Dict[str, int] = field(default_factory=dict)
+
+    def add(
+        self,
+        *,
+        automation: str,
+        provider: str,
+        severity: str,
+        status: str,
+        message: str,
+        remediation: str = "",
+    ) -> AuditFinding:
+        finding = AuditFinding(
+            provider=provider,
+            severity=severity,
+            message=message,
+            automation=automation,
+            status=status,
+            remediation=remediation or "",
+        )
+        self.findings.append(finding)
+        self.provider_counts[provider] = self.provider_counts.get(provider, 0) + 1
+        self.severity_counts[severity] = self.severity_counts.get(severity, 0) + 1
+        self.status_counts[status] = self.status_counts.get(status, 0) + 1
+        return finding
+
+    def to_json(self) -> Dict[str, object]:
+        return {
+            "correlation_id": self.correlation_id,
+            "automations": [
+                {
+                    "name": finding.automation or finding.provider,
+                    "status": finding.status,
+                    "provider": finding.provider,
+                    "severity": finding.severity,
+                    "message": finding.message,
+                    "remediation": finding.remediation or "",
+                }
+                for finding in self.findings
+            ],
+            "counters": {
+                "providers": self.provider_counts,
+                "severities": self.severity_counts,
+                "statuses": self.status_counts,
+            },
+        }
+
+    def rows(self) -> Iterator[dict[str, str]]:
+        for finding in self.findings:
+            yield finding.to_row()
+
+
+def compute_correlation_id(root: Path, seed: str = DEFAULT_SEED) -> str:
+    digest = hashlib.sha256()
+    digest.update(str(root.resolve()).encode("utf-8"))
+    digest.update((seed or "").encode("utf-8"))
+    return digest.hexdigest()[:12]
+
+
+def _audit_directory(
+    result: AuditResult,
+    root: Path,
+    directory: Path,
+    *,
+    automation: str,
+    provider: str,
+    require_exec: bool,
+    missing_severity: str = "medium",
+) -> None:
+    path = (root / directory).resolve()
+    if not directory:
+        result.add(
+            automation=automation,
+            provider=provider,
+            severity="high",
+            status="FAIL",
+            message="مسیر پیکربندی نامعتبر است.",
+            remediation="مسیر صحیح را تعیین کنید.",
+        )
+        return
+    if not path.exists():
+        result.add(
+            automation=automation,
+            provider=provider,
+            severity=missing_severity,
+            status="WARN",
+            message=f"پوشهٔ {directory} یافت نشد.",
+            remediation="در صورت نیاز پوشه را ایجاد کنید.",
+        )
+        return
+    try:
+        entries = list(path.iterdir())
+    except OSError as exc:  # pragma: no cover - exercised via error handling tests
+        result.add(
+            automation=automation,
+            provider=provider,
+            severity="high",
+            status="FAIL",
+            message=f"خواندن پوشهٔ {directory} ممکن نشد: {exc}",
+            remediation="دسترسی فایل را بررسی کنید.",
+        )
+        return
+
+    invalid: list[str] = []
+    for entry in entries:
+        if entry.name.endswith(".sample"):
+            continue
+        if entry.is_file():
+            check_flag = os.X_OK if require_exec else os.R_OK
+            if not os.access(entry, check_flag):
+                invalid.append(entry.name)
+    if invalid:
+        result.add(
+            automation=automation,
+            provider=provider,
+            severity="high",
+            status="FAIL",
+            message="آیتم‌های غیرمجاز: " + ", ".join(sorted(invalid)),
+            remediation="مجوز اجرا/خواندن را اصلاح کنید.",
+        )
+    else:
+        result.add(
+            automation=automation,
+            provider=provider,
+            severity="low",
+            status="PASS",
+            message=f"پوشهٔ {directory} بدون خطاست.",
+            remediation="",
+        )
+
+
+def _audit_config_file(result: AuditResult, root: Path, file_path: Path) -> None:
+    path = (root / file_path).resolve()
+    automation = f"config:{file_path}"
+    if not path.exists():
+        result.add(
+            automation=automation,
+            provider="config",
+            severity="medium",
+            status="WARN",
+            message=f"فایل {file_path} پیدا نشد.",
+            remediation="در صورت نیاز فایل را اضافه کنید.",
+        )
+        return
+    if not os.access(path, os.R_OK):
+        result.add(
+            automation=automation,
+            provider="config",
+            severity="high",
+            status="FAIL",
+            message=f"فایل {file_path} قابل‌خواندن نیست.",
+            remediation="مجوزهای فایل را بازبینی کنید.",
+        )
+        return
+    if path.stat().st_size == 0:
+        result.add(
+            automation=automation,
+            provider="config",
+            severity="medium",
+            status="WARN",
+            message=f"فایل {file_path} خالی است.",
+            remediation="مقداردهی اولیه را انجام دهید.",
+        )
+        return
+    result.add(
+        automation=automation,
+        provider="config",
+        severity="low",
+        status="PASS",
+        message=f"فایل {file_path} آماده است.",
+    )
+
+
+def audit_ci_surfaces(result: AuditResult, root: Path) -> None:
+    ci_files = list(iter_ci_files(root))
+    if not ci_files:
+        result.add(
+            automation="ci",
+            provider="ci",
+            severity="medium",
+            status="WARN",
+            message="هیچ فایل CI یافت نشد.",
+            remediation="پیکربندی خطوط CI را اضافه کنید.",
+        )
+        return
+
+    for path in ci_files:
+        relative = path.relative_to(root)
+
+        async def analyze() -> Dict[str, List[str]]:
+            return analyze_ci_file(path)
+
+        try:
+            analysis = asyncio.run(
+                retry_async(analyze, config=RetryConfig(attempts=3, base_delay=0.01, jitter=0.0))
+            )
+        except Exception as exc:  # pragma: no cover - exercised via failure paths
+            result.add(
+                automation=f"ci:{relative}",
+                provider="ci",
+                severity="high",
+                status="FAIL",
+                message=f"تحلیل فایل CI ناموفق بود: {exc}",
+                remediation="ساختار فایل را بررسی کنید.",
+            )
+            continue
+
+        message = "مرحله‌ها: {steps}؛ متغیرها: {env}".format(
+            steps=", ".join(analysis["steps"]) or "هیچ",
+            env=", ".join(analysis["env"]) or "هیچ",
+        )
+        result.add(
+            automation=f"ci:{relative}",
+            provider="ci",
+            severity="info",
+            status="PASS",
+            message=message,
+        )
+
+
+def audit_repo(root: Path) -> AuditResult:
+    result = AuditResult(correlation_id=compute_correlation_id(root))
+    for directory in HOOK_DIRECTORIES:
+        _audit_directory(
+            result,
+            root,
+            directory,
+            automation=f"hooks:{directory}",
+            provider="hooks",
+            require_exec=True,
+            missing_severity="medium",
+        )
+    for directory in SCRIPT_DIRECTORIES:
+        _audit_directory(
+            result,
+            root,
+            directory,
+            automation=f"dir:{directory}",
+            provider="fs",
+            require_exec=False,
+            missing_severity="low",
+        )
+    for file_path in CONFIG_FILES:
+        _audit_config_file(result, root, file_path)
+    audit_ci_surfaces(result, root)
+    return result
+
+
+def write_reports(root: Path, result: AuditResult, *, with_markdown: bool, with_csv: bool) -> None:
+    reports_dir = root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    json_path = reports_dir / "automation_audit.json"
+    md_path = reports_dir / "automation_audit.md"
+    csv_path = reports_dir / "automation_audit.csv"
+
+    with atomic_writer(json_path, mode="w", encoding="utf-8") as handle:
+        json.dump(result.to_json(), handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    if with_markdown:
+        markdown = render_markdown(result.findings)
+        with atomic_writer(md_path, mode="w", encoding="utf-8") as handle:
+            handle.write(markdown)
+    if with_csv:
+        writer = CSVSafeWriter(csv_path, headers=CSV_HEADERS)
+        writer.write(result.rows())
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Automation audit CLI")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repository root")
+    parser.add_argument("--seed", type=str, default=DEFAULT_SEED)
+    parser.add_argument("--no-markdown", action="store_true")
+    parser.add_argument("--csv", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    configure_logging()
+    args = parse_args(argv)
+    root = Path(args.root or Path.cwd()).resolve()
+    correlation_id = compute_correlation_id(root, args.seed)
+    set_correlation_id(correlation_id)
+    metrics = build_metrics()
+    metrics.audit_runs.inc()
+    result = audit_repo(root)
+    if any(finding.status == "FAIL" for finding in result.findings):
+        metrics.audit_failures.inc()
+    log_json("audit_completed", findings=len(result.findings), correlation_id=correlation_id)
+    write_reports(root, result, with_markdown=not args.no_markdown, with_csv=args.csv)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/automation_audit/counter.py
+++ b/automation_audit/counter.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .providers.academic_year import AcademicYearProvider
+
+COUNTER_RE = re.compile(r"^\d{2}(357|373)\d{4}$")
+PREFIX_BY_GENDER = {0: "373", 1: "357"}
+
+
+@dataclass
+class CounterBuilder:
+    year_provider: AcademicYearProvider
+
+    def build(self, gender: int, sequence: int) -> str:
+        prefix = PREFIX_BY_GENDER[gender]
+        year = self.year_provider.year_code()
+        value = f"{year}{prefix}{sequence:04d}"
+        if not COUNTER_RE.fullmatch(value):
+            raise ValueError("شناسه شمارنده نامعتبر است.")
+        return value

--- a/automation_audit/debug.py
+++ b/automation_audit/debug.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict
+
+import redis
+
+from .ratelimit import RateLimiter
+
+
+def get_debug_context(redis_client: redis.Redis, limiter: RateLimiter) -> Dict[str, Any]:
+    return {
+        "redis_keys": sorted(k.decode() if isinstance(k, bytes) else k for k in redis_client.keys("*")),
+        "rate_limit_state": limiter.config.namespace,
+        "middleware_order": ["RateLimit", "Idempotency", "Auth"],
+        "env": os.getenv("GITHUB_ACTIONS", "local"),
+        "timestamp": time.time(),
+    }

--- a/automation_audit/exporter.py
+++ b/automation_audit/exporter.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from .fs_atomic import atomic_writer
+
+
+FORMULA_PREFIXES = ("=", "+", "-", "@")
+
+
+@dataclass
+class AuditFinding:
+    provider: str
+    severity: str
+    message: str
+    automation: str = ""
+    status: str = "PASS"
+    remediation: str | None = None
+
+    def to_row(self) -> dict[str, str]:
+        return {
+            "automation": self.automation,
+            "status": self.status,
+            "provider": self.provider,
+            "severity": self.severity,
+            "message": self.message,
+            "remediation": (self.remediation or ""),
+        }
+
+
+class CSVSafeWriter:
+    def __init__(self, path: Path, headers: List[str]):
+        self.path = path
+        self.headers = headers
+
+    def write(self, rows: Iterable[dict[str, str]]) -> None:
+        with atomic_writer(self.path, encoding="utf-8", mode="w") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=self.headers,
+                quoting=csv.QUOTE_ALL,
+                extrasaction="ignore",
+                lineterminator="\r\n",
+            )
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({key: self._guard(value) for key, value in row.items()})
+
+    @staticmethod
+    def _guard(value: str | None) -> str:
+        if value is None:
+            return ""
+        text = str(value)
+        if text and text[0] in FORMULA_PREFIXES:
+            return "'" + text
+        return text
+
+
+def render_markdown(findings: Iterable[AuditFinding]) -> str:
+    lines = [
+        "| Automation | Status | Provider | Severity | Message | Remediation |",
+        "|---|---|---|---|---|---|",
+    ]
+    for finding in findings:
+        lines.append(
+            "| {automation} | {status} | {provider} | {severity} | {message} | {remediation} |".format(
+                automation=finding.automation or "-",
+                status=finding.status,
+                provider=finding.provider,
+                severity=finding.severity,
+                message=finding.message,
+                remediation=finding.remediation or "-",
+            )
+        )
+    return "\n".join(lines)

--- a/automation_audit/fs_atomic.py
+++ b/automation_audit/fs_atomic.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, TextIO
+
+__all__ = ["atomic_writer", "atomic_write_text"]
+
+
+def _fsync_directory(path: Path) -> None:
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def atomic_writer(target: Path, *, mode: str = "w", encoding: str | None = "utf-8") -> Iterator[TextIO]:
+    target = Path(target)
+    tmp_dir = target.parent
+    tmp_fd: int
+    tmp_path: str
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=tmp_dir, prefix=target.name, suffix=".part")
+    try:
+        with os.fdopen(tmp_fd, mode, encoding=encoding) as handle:
+            yield handle
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, target)
+        _fsync_directory(target.parent)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def atomic_write_text(target: Path, chunks: Iterable[str], *, encoding: str = "utf-8", newline: str = "\n") -> None:
+    with atomic_writer(target, mode="w", encoding=encoding) as handle:
+        for chunk in chunks:
+            handle.write(chunk)
+            if newline and not chunk.endswith(newline):
+                handle.write(newline)

--- a/automation_audit/idem.py
+++ b/automation_audit/idem.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import redis
+
+IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24
+
+
+@dataclass
+class IdempotencyStore:
+    client: redis.Redis
+    namespace: str = "automation_audit:idemp"
+
+    def _key(self, key: str) -> str:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return f"{self.namespace}:{digest}"
+
+    def put_if_absent(self, key: str, payload: Any) -> bool:
+        redis_key = self._key(key)
+        if not self.client.set(redis_key, json.dumps(payload), nx=True, ex=IDEMPOTENCY_TTL_SECONDS):
+            return False
+        return True
+
+    def get(self, key: str) -> Any | None:
+        redis_key = self._key(key)
+        value = self.client.get(redis_key)
+        if not value:
+            return None
+        return json.loads(value)
+
+    def clear_namespace(self) -> None:
+        pattern = f"{self.namespace}:*"
+        for key in self.client.scan_iter(pattern):
+            self.client.delete(key)

--- a/automation_audit/logging.py
+++ b/automation_audit/logging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from typing import Any, Dict
+
+MASKED_FIELDS = {"email", "phone", "national_id"}
+CORRELATION_ID = ContextVar("correlation_id", default="unknown")
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - exercised via tests
+        payload: Dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, UTC).isoformat().replace("+00:00", "Z"),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "module": record.module,
+            "correlation_id": CORRELATION_ID.get(),
+        }
+        for key, value in getattr(record, "extra", {}).items():
+            payload[key] = _mask_if_needed(key, value)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _mask_if_needed(key: str, value: Any) -> Any:
+    if key in MASKED_FIELDS and isinstance(value, str):
+        return f"***{hash(value) & 0xffff:x}"
+    return value
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers = [handler]
+    app_logger = logging.getLogger("automation_audit")
+    app_logger.setLevel(level)
+    app_logger.propagate = True
+
+
+def set_correlation_id(value: str) -> None:
+    CORRELATION_ID.set(value)
+
+
+def log_json(message: str, **extra: Any) -> None:
+    logger = logging.getLogger("automation_audit")
+    logger.info(message, extra={"extra": extra})

--- a/automation_audit/metrics.py
+++ b/automation_audit/metrics.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from prometheus_client import Counter, CollectorRegistry, generate_latest
+
+AUDIT_NAMESPACE = "automation_audit"
+
+
+@dataclass
+class Metrics:
+    registry: CollectorRegistry
+    audit_runs: Counter
+    audit_failures: Counter
+    retry_attempts: Counter
+    retry_exhausted: Counter
+
+
+def build_metrics(registry: Optional[CollectorRegistry] = None) -> Metrics:
+    registry = registry or CollectorRegistry()
+    audit_runs = Counter(
+        "runs_total",
+        "Total automation audit executions",
+        namespace=AUDIT_NAMESPACE,
+        registry=registry,
+    )
+    audit_failures = Counter(
+        "failures_total",
+        "Automation audit failures",
+        namespace=AUDIT_NAMESPACE,
+        registry=registry,
+    )
+    retry_attempts = Counter(
+        "retry_attempts_total",
+        "Retry attempts performed",
+        namespace=AUDIT_NAMESPACE,
+        registry=registry,
+    )
+    retry_exhausted = Counter(
+        "retry_exhausted_total",
+        "Retries exhausted",
+        namespace=AUDIT_NAMESPACE,
+        registry=registry,
+    )
+    return Metrics(registry, audit_runs, audit_failures, retry_attempts, retry_exhausted)
+
+
+def render_metrics(metrics: Metrics) -> bytes:
+    return generate_latest(metrics.registry)

--- a/automation_audit/normalize.py
+++ b/automation_audit/normalize.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import unicodedata
+from typing import Iterable
+
+PERSIAN_YEH = "ی"
+ARABIC_YEH = "ي"
+PERSIAN_KEHEH = "ک"
+ARABIC_KAF = "ك"
+ZERO_WIDTHS = {
+    "\u200c",
+    "\u200d",
+    "\ufeff",
+    "\u200b",
+}
+
+FA_AR_DIGITS = {
+    "۰": "0",
+    "۱": "1",
+    "۲": "2",
+    "۳": "3",
+    "۴": "4",
+    "۵": "5",
+    "۶": "6",
+    "۷": "7",
+    "۸": "8",
+    "۹": "9",
+    "٠": "0",
+    "١": "1",
+    "٢": "2",
+    "٣": "3",
+    "٤": "4",
+    "٥": "5",
+    "٦": "6",
+    "٧": "7",
+    "٨": "8",
+    "٩": "9",
+}
+
+
+def fold_digits(value: str) -> str:
+    return "".join(FA_AR_DIGITS.get(ch, ch) for ch in value)
+
+
+def strip_control_and_zero_width(value: str) -> str:
+    return "".join(ch for ch in value if ch not in ZERO_WIDTHS and not unicodedata.category(ch).startswith("C"))
+
+
+def normalize_text(value: str) -> str:
+    value = fold_digits(value)
+    value = value.replace(ARABIC_YEH, PERSIAN_YEH).replace(ARABIC_KAF, PERSIAN_KEHEH)
+    value = strip_control_and_zero_width(value)
+    value = unicodedata.normalize("NFKC", value)
+    return value.strip()

--- a/automation_audit/providers/academic_year.py
+++ b/automation_audit/providers/academic_year.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class AcademicYearProvider:
+    clock: Callable[[], float]
+
+    def year_code(self) -> str:
+        year = int(self.clock())
+        return str(year)[-2:]

--- a/automation_audit/providers/special_schools.py
+++ b/automation_audit/providers/special_schools.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class SpecialSchoolsRoster:
+    year: str
+    mapping: Dict[str, str]
+
+    def student_type(self, student_id: str) -> str:
+        return self.mapping.get(student_id, "unknown")

--- a/automation_audit/ratelimit.py
+++ b/automation_audit/ratelimit.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import redis
+
+
+@dataclass
+class RateLimitConfig:
+    capacity: int = 5
+    refill_rate: float = 1.0
+    namespace: str = "automation_audit:ratelimit"
+
+
+class RateLimiter:
+    def __init__(self, client: redis.Redis, config: RateLimitConfig, clock: Callable[[], float] = time.time) -> None:
+        self.client = client
+        self.config = config
+        self.clock = clock
+
+    def _key(self, token: str) -> str:
+        return f"{self.config.namespace}:{token}"
+
+    def allow(self, token: str) -> bool:
+        now = self.clock()
+        key = self._key(token)
+        bucket = self.client.hgetall(key)
+
+        def _to_float(value):
+            if value in (None, b"", ""):
+                return 0.0
+            if isinstance(value, bytes):
+                value = value.decode()
+            return float(value)
+
+        tokens = _to_float(bucket.get(b"tokens") or bucket.get("tokens") or 0)
+        last = _to_float(bucket.get(b"ts") or bucket.get("ts") or 0)
+        tokens = min(self.config.capacity, tokens + (now - last) * self.config.refill_rate)
+        if tokens < 1:
+            return False
+        tokens -= 1
+        self.client.hset(key, mapping={"tokens": tokens, "ts": now})
+        return True
+
+    def clear(self) -> None:
+        pattern = f"{self.config.namespace}:*"
+        for key in self.client.scan_iter(pattern):
+            self.client.delete(key)

--- a/automation_audit/retry.py
+++ b/automation_audit/retry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional, Protocol, TypeVar
+
+from .metrics import Metrics
+
+T = TypeVar("T")
+
+
+class SleepFn(Protocol):
+    async def __call__(self, delay: float) -> None:  # pragma: no cover - protocol definition
+        ...
+
+
+async def default_sleep(delay: float) -> None:
+    await asyncio.sleep(delay)
+
+
+@dataclass
+class RetryConfig:
+    attempts: int = 3
+    base_delay: float = 0.05
+    jitter: float = 0.01
+    multiplier: float = 2.0
+
+
+async def retry_async(
+    coro_factory: Callable[[], Awaitable[T]],
+    *,
+    config: RetryConfig,
+    metrics: Optional[Metrics] = None,
+    sleep: SleepFn = default_sleep,
+) -> T:
+    if config.attempts < 1:
+        raise ValueError("حداقل یک تلاش لازم است.")
+
+    delay = config.base_delay
+    last_exc: Exception | None = None
+    for attempt in range(1, config.attempts + 1):
+        try:
+            if metrics:
+                metrics.retry_attempts.inc()
+            return await coro_factory()
+        except Exception as exc:  # pragma: no cover - failure path asserted in tests
+            last_exc = exc
+            if attempt == config.attempts:
+                if metrics:
+                    metrics.retry_exhausted.inc()
+                raise
+            jitter = random.uniform(-config.jitter, config.jitter)
+            await sleep(max(delay + jitter, 0.0))
+            delay *= config.multiplier
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("Retry concluded without execution")

--- a/automation_audit/validation.py
+++ b/automation_audit/validation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .normalize import fold_digits
+
+REG_CENTER_ALLOWED = {0, 1, 2}
+REG_STATUS_ALLOWED = {0, 1, 3}
+PHONE_RE = re.compile(r"^09\d{9}$")
+
+
+@dataclass
+class Enrollment:
+    reg_center: int
+    reg_status: int
+    phone: str
+
+    def validate(self) -> None:
+        if self.reg_center not in REG_CENTER_ALLOWED:
+            raise ValueError("کد مرکز ثبت‌نام نامعتبر است.")
+        if self.reg_status not in REG_STATUS_ALLOWED:
+            raise ValueError("وضعیت ثبت‌نام نامعتبر است.")
+        normalized_phone = fold_digits(self.phone)
+        if not PHONE_RE.fullmatch(normalized_phone):
+            raise ValueError("شماره همراه نامعتبر است.")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = -q -p no:pytestqt
-pythonpath = src
+pythonpath = src .
 testpaths = tests
 asyncio_default_fixture_loop_scope = function
 markers =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,6 @@ alembic>=1.12
 prometheus_client>=0.16
 PyYAML>=6.0
 types-PyYAML>=6.0.12
+fastapi>=0.110
+redis>=5.0
+fakeredis>=2.19

--- a/tests/automation_audit/conftest.py
+++ b/tests/automation_audit/conftest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from typing import Callable
+
+import fakeredis
+import pytest
+from prometheus_client import CollectorRegistry
+
+from automation_audit.metrics import build_metrics
+
+
+@pytest.fixture
+def redis_client() -> Iterator[fakeredis.FakeStrictRedis]:
+    client = fakeredis.FakeStrictRedis()
+    client.flushall()
+    yield client
+    client.flushall()
+
+
+@pytest.fixture
+def metrics_registry() -> CollectorRegistry:
+    return CollectorRegistry()
+
+
+@pytest.fixture
+def metrics(metrics_registry):
+    return build_metrics(metrics_registry)
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch):
+    value = 1700000000.0
+
+    def clock() -> float:
+        return value
+
+    monkeypatch.setattr("time.time", lambda: value)
+    return clock

--- a/tests/automation_audit/debug/test_assert_context.py
+++ b/tests/automation_audit/debug/test_assert_context.py
@@ -1,0 +1,9 @@
+from automation_audit.debug import get_debug_context
+from automation_audit.ratelimit import RateLimitConfig, RateLimiter
+
+
+def test_context_in_asserts(redis_client):
+    limiter = RateLimiter(redis_client, RateLimitConfig())
+    context = get_debug_context(redis_client, limiter)
+    assert context["middleware_order"] == ["RateLimit", "Idempotency", "Auth"]
+    assert context["env"] in {"local", "true"}

--- a/tests/automation_audit/derive/test_correlation_and_counters.py
+++ b/tests/automation_audit/derive/test_correlation_and_counters.py
@@ -1,0 +1,7 @@
+from automation_audit.cli import compute_correlation_id
+
+
+def test_correlation_12hex(tmp_path):
+    cid = compute_correlation_id(tmp_path)
+    assert len(cid) == 12
+    int(cid, 16)

--- a/tests/automation_audit/errors/test_persian_envelopes.py
+++ b/tests/automation_audit/errors/test_persian_envelopes.py
@@ -1,0 +1,17 @@
+import asyncio
+
+import httpx
+
+from automation_audit.api import create_app
+
+
+def test_error_messages(redis_client):
+    app = create_app(redis_client=redis_client, auth_tokens=["token"])
+
+    async def call():
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            return await client.post("/audit", headers={"authorization": "Bearer token"})
+
+    response = asyncio.run(call())
+    assert response.status_code == 400
+    assert "کلید تکرار" in response.json()["detail"]

--- a/tests/automation_audit/excel/test_csv_safety.py
+++ b/tests/automation_audit/excel/test_csv_safety.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from automation_audit.exporter import AuditFinding, CSVSafeWriter
+
+
+def test_always_quote_and_guard(tmp_path: Path):
+    path = tmp_path / "report.csv"
+    writer = CSVSafeWriter(path, headers=["provider", "severity", "message"])
+    writer.write([{"provider": "ci", "severity": "high", "message": "=rm"}])
+    content = path.read_text(encoding="utf-8")
+    assert '"\'=rm"' in content

--- a/tests/automation_audit/hygiene/test_fixtures.py
+++ b/tests/automation_audit/hygiene/test_fixtures.py
@@ -1,0 +1,8 @@
+from automation_audit.idem import IdempotencyStore
+
+
+def test_namespace_isolation(redis_client):
+    store = IdempotencyStore(redis_client, namespace="ns1")
+    store.put_if_absent("key", {"a": 1})
+    other = IdempotencyStore(redis_client, namespace="ns2")
+    assert other.get("key") is None

--- a/tests/automation_audit/hygiene/test_state.py
+++ b/tests/automation_audit/hygiene/test_state.py
@@ -1,0 +1,23 @@
+from prometheus_client import CollectorRegistry
+
+from automation_audit.idem import IdempotencyStore
+from automation_audit.metrics import build_metrics
+
+
+def test_redis_clean(redis_client):
+    redis_client.set("x", "1")
+    redis_client.flushall()
+    assert redis_client.dbsize() == 0
+
+
+def test_prom_registry_reset(metrics_registry):
+    metrics = build_metrics(metrics_registry)
+    metrics.audit_runs.inc()
+    assert isinstance(metrics.registry, CollectorRegistry)
+
+
+def test_unique_namespace(redis_client):
+    first = IdempotencyStore(redis_client, namespace="automation_audit:idemp:first")
+    second = IdempotencyStore(redis_client, namespace="automation_audit:idemp:second")
+    first.put_if_absent("key", {"value": 1})
+    assert second.get("key") is None

--- a/tests/automation_audit/io/test_atomic.py
+++ b/tests/automation_audit/io/test_atomic.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from automation_audit.fs_atomic import atomic_write_text
+
+
+def test_atomic_write(tmp_path: Path):
+    path = tmp_path / "file.txt"
+    atomic_write_text(path, ["hello", "world"], newline="\n")
+    assert path.read_text() == "hello\nworld\n"

--- a/tests/automation_audit/logging/test_json_logs.py
+++ b/tests/automation_audit/logging/test_json_logs.py
@@ -1,0 +1,13 @@
+import json
+
+from automation_audit.logging import configure_logging, log_json, set_correlation_id
+
+
+def test_masking_no_pii(capfd):
+    configure_logging()
+    set_correlation_id("abc123")
+    log_json("msg", email="user@example.com")
+    out = capfd.readouterr().err.strip().splitlines()[-1]
+    record = json.loads(out)
+    assert record["email"].startswith("***")
+    assert record["correlation_id"] == "abc123"

--- a/tests/automation_audit/mw/test_order.py
+++ b/tests/automation_audit/mw/test_order.py
@@ -1,0 +1,8 @@
+from automation_audit.api import IdempotencyMiddleware, RateLimitMiddleware, create_app
+from automation_audit.auth import AuthMiddleware
+
+
+def test_middleware_order(redis_client):
+    app = create_app(redis_client=redis_client, auth_tokens=["token"], rate_limit_config=None)
+    chain = [mw.cls for mw in app.user_middleware]
+    assert chain == [RateLimitMiddleware, IdempotencyMiddleware, AuthMiddleware]

--- a/tests/automation_audit/normalize/test_text_rules.py
+++ b/tests/automation_audit/normalize/test_text_rules.py
@@ -1,0 +1,7 @@
+from automation_audit.normalize import fold_digits, normalize_text
+
+
+def test_nfkc_digit_fold():
+    value = "٠۱۲٣\u200cك"
+    result = normalize_text(value)
+    assert result == "0123ک"

--- a/tests/automation_audit/obs/test_metrics.py
+++ b/tests/automation_audit/obs/test_metrics.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from automation_audit.metrics import build_metrics
+from automation_audit.retry import RetryConfig, retry_async
+
+
+def test_retry_exhaustion_metrics(metrics):
+    async def run():
+        async def failing():
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            await retry_async(failing, config=RetryConfig(attempts=2, base_delay=0.0, jitter=0.0), metrics=metrics, sleep=lambda _: asyncio.sleep(0))
+        assert metrics.retry_exhausted._value.get() == 1.0
+
+    asyncio.run(run())
+
+
+def test_audit_counters(metrics):
+    metrics.audit_runs.inc()
+    metrics.audit_failures.inc()
+    assert metrics.audit_runs._value.get() == 1.0
+    assert metrics.audit_failures._value.get() == 1.0

--- a/tests/automation_audit/perf/test_memory_budget.py
+++ b/tests/automation_audit/perf/test_memory_budget.py
@@ -1,0 +1,12 @@
+import tracemalloc
+
+from automation_audit.exporter import AuditFinding, render_markdown
+
+
+def test_memory_ceiling():
+    tracemalloc.start()
+    findings = [AuditFinding("ci", "low", "msg") for _ in range(1000)]
+    render_markdown(findings)
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    assert peak < 5 * 10**7

--- a/tests/automation_audit/perf/test_p95.py
+++ b/tests/automation_audit/perf/test_p95.py
@@ -1,0 +1,11 @@
+import time
+
+from automation_audit.cli import compute_correlation_id
+
+
+def test_latency_budget(tmp_path):
+    start = time.perf_counter()
+    for _ in range(1000):
+        compute_correlation_id(tmp_path)
+    duration = time.perf_counter() - start
+    assert duration < 0.25

--- a/tests/automation_audit/phase1/test_enums.py
+++ b/tests/automation_audit/phase1/test_enums.py
@@ -1,0 +1,8 @@
+import pytest
+
+from automation_audit.validation import Enrollment
+
+
+def test_enums():
+    with pytest.raises(ValueError):
+        Enrollment(reg_center=9, reg_status=0, phone="09123456789").validate()

--- a/tests/automation_audit/phase1/test_phone_text.py
+++ b/tests/automation_audit/phase1/test_phone_text.py
@@ -1,0 +1,9 @@
+import pytest
+
+from automation_audit.validation import Enrollment
+
+
+def test_phone_regex():
+    Enrollment(reg_center=1, reg_status=1, phone="۰۹۱۲۳۴۵۶۷۸۹").validate()
+    with pytest.raises(ValueError):
+        Enrollment(reg_center=1, reg_status=1, phone="123").validate()

--- a/tests/automation_audit/phase2/test_counter_rules.py
+++ b/tests/automation_audit/phase2/test_counter_rules.py
@@ -1,0 +1,12 @@
+import pytest
+
+from automation_audit.counter import COUNTER_RE, CounterBuilder
+from automation_audit.providers.academic_year import AcademicYearProvider
+
+
+def test_counter_regex(frozen_clock):
+    builder = CounterBuilder(AcademicYearProvider(clock=frozen_clock))
+    value = builder.build(0, 42)
+    assert COUNTER_RE.fullmatch(value)
+    with pytest.raises(KeyError):
+        builder.build(9, 1)

--- a/tests/automation_audit/phase2/test_idem.py
+++ b/tests/automation_audit/phase2/test_idem.py
@@ -1,0 +1,9 @@
+from automation_audit.idem import IDEMPOTENCY_TTL_SECONDS, IdempotencyStore
+
+
+def test_ttl_24h_and_uniqueness(redis_client):
+    store = IdempotencyStore(redis_client)
+    assert store.put_if_absent("key", {"a": 1})
+    ttl = redis_client.ttl(next(iter(redis_client.scan_iter(f"{store.namespace}:*"))))
+    assert ttl == IDEMPOTENCY_TTL_SECONDS
+    assert not store.put_if_absent("key", {"a": 2})

--- a/tests/automation_audit/phase6_exporter/test_export_csv.py
+++ b/tests/automation_audit/phase6_exporter/test_export_csv.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from automation_audit.exporter import AuditFinding, CSVSafeWriter
+
+
+def test_excel_safety_streaming(tmp_path: Path):
+    path = tmp_path / "export.csv"
+    writer = CSVSafeWriter(
+        path,
+        headers=["automation", "status", "provider", "severity", "message", "remediation"],
+    )
+    rows = (finding.to_row() for finding in [AuditFinding("ci", "low", "text", automation="ci", status="PASS")])
+    writer.write(rows)
+    assert path.read_text().startswith("\"automation\"")

--- a/tests/automation_audit/retry/test_backoff.py
+++ b/tests/automation_audit/retry/test_backoff.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import pytest
+
+from automation_audit.retry import RetryConfig, retry_async
+
+
+def test_backoff_jitter(monkeypatch):
+    delays = []
+
+    async def sleeper(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr("automation_audit.retry.random.uniform", lambda a, b: 0)
+
+    calls = 0
+
+    async def failing():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError
+
+    async def run():
+        with pytest.raises(RuntimeError):
+            await retry_async(failing, config=RetryConfig(attempts=2, base_delay=0.1, jitter=0.0), sleep=sleeper)
+
+    asyncio.run(run())
+    assert delays[0] == pytest.approx(0.1)
+    assert calls == 2

--- a/tests/automation_audit/security/test_auth.py
+++ b/tests/automation_audit/security/test_auth.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import httpx
+
+from automation_audit.api import create_app
+
+
+def test_bearer_and_ip(redis_client):
+    app = create_app(
+        redis_client=redis_client,
+        auth_tokens=["token"],
+        metrics_token="metrics-token",
+        metrics_allowed_ips={"127.0.0.1"},
+    )
+
+    async def call(path: str, headers: dict[str, str] | None = None):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            return await client.get(path, headers=headers or {})
+
+    async def flow():
+        ok = await call(
+            "/metrics",
+            headers={
+                "authorization": "Bearer metrics-token",
+                "x-forwarded-for": "127.0.0.1",
+            },
+        )
+        return ok.status_code
+
+    status_code = asyncio.run(flow())
+    assert status_code == 200

--- a/tests/automation_audit/security/test_metrics_guard.py
+++ b/tests/automation_audit/security/test_metrics_guard.py
@@ -1,0 +1,16 @@
+import asyncio
+
+import httpx
+
+from automation_audit.api import create_app
+
+
+def test_protected_metrics(redis_client):
+    app = create_app(redis_client=redis_client, auth_tokens=["token"])
+
+    async def call():
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            return await client.get("/metrics", headers={"authorization": "Bearer token"})
+
+    response = asyncio.run(call())
+    assert response.status_code == 403

--- a/tests/automation_audit/time/test_clock.py
+++ b/tests/automation_audit/time/test_clock.py
@@ -1,0 +1,6 @@
+from automation_audit.providers.academic_year import AcademicYearProvider
+
+
+def test_clock_freeze(frozen_clock):
+    provider = AcademicYearProvider(clock=frozen_clock)
+    assert provider.year_code() == str(int(frozen_clock()))[-2:]

--- a/tests/automation_audit/time/test_timing_control.py
+++ b/tests/automation_audit/time/test_timing_control.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import pytest
+
+from automation_audit.retry import RetryConfig, retry_async
+
+
+def test_retry_timing(monkeypatch):
+    sequence = []
+
+    async def sleeper(delay):
+        sequence.append(delay)
+
+    monkeypatch.setattr("automation_audit.retry.random.uniform", lambda a, b: 0)
+
+    async def fail():
+        raise RuntimeError
+
+    async def run():
+        with pytest.raises(RuntimeError):
+            await retry_async(fail, config=RetryConfig(attempts=2, base_delay=0.05, jitter=0.0), sleep=sleeper)
+
+    asyncio.run(run())
+    assert sequence == [0.05]


### PR DESCRIPTION
## Summary
- harden the automation_audit CLI to record provider/status counters, audit git hooks/configs, and emit atomic JSON/Markdown/CSV artifacts with Excel-safe streaming rows
- extend the automation_audit service utilities with IP-gated metrics auth, streaming CI analysis, and a typed retry helper to support deterministic audits
- reorganize the automation_audit test suite hierarchy and add coverage for metrics bearer/IP enforcement and namespace hygiene evidence names

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/automation_audit -q

------
https://chatgpt.com/codex/tasks/task_e_68d91b07f6108321b380ad6bd49f4b14