### PR TITLE
Add deterministic PII scan to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
+      - name: اسکن دادهٔ حساس
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          make pii-scan
       - name: اجرای گیت‌های استاتیک و امنیتی
         env:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ pytest:
     - export PYTHONWARNINGS=default
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt -r requirements-dev.txt
+    - PYTHONPATH="$CI_PROJECT_DIR" make pii-scan
     - |
       export PYTHONWARNINGS=error
       export PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'

--- a/scripts/ci_no_pii_scan.py
+++ b/scripts/ci_no_pii_scan.py
@@ -1,0 +1,235 @@
+"""Deterministic PII scanner for CI pipelines.
+
+این اسکریپت به صورت دترمینیستیک کل مخزن را برای داده‌های حساس
+بررسی می‌کند، یافته‌ها را به صورت HMAC ماسک کرده و در گزارش JSON
+ذخیره می‌نماید. در صورت مشاهده دادهٔ حساس، خروجی اسکریپت با کد ۱
+خاتمه می‌یابد تا خطوط CI متوقف شوند.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Optional, Sequence, Tuple
+
+import re
+
+from src.phase6_import_to_sabt.sanitization import sanitize_phone, sanitize_text
+
+
+class ScanError(RuntimeError):
+    """خطاهای قابل پیش‌بینی در فرآیند اسکن."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    """یافتهٔ دادهٔ حساس."""
+
+    file: Path
+    line: int
+    kind: str
+    masked: str
+
+
+@dataclass(frozen=True)
+class _Pattern:
+    name: str
+    regex: "re.Pattern[str]"
+    variant: str
+
+
+SCAN_EXTENSIONS = {
+    ".py",
+    ".log",
+    ".txt",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".md",
+    ".csv",
+}
+
+EXCLUDE_DIRS = {
+    ".git",
+    "__pycache__",
+    "tmp",
+    "tmpfile",
+    "node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+    "reports",  # خروجی‌ها مجدداً بررسی نمی‌شوند
+}
+
+
+PATTERNS: Tuple[_Pattern, ...] = (
+    _Pattern("national_id", re.compile(r"\b\d{10}\b"), "sanitized"),
+    _Pattern("mobile", re.compile(r"09\d{9}"), "phone"),
+)
+
+
+def coerce_to_text(value: Optional[object]) -> str:
+    """Ensure any input is converted to a safe string for scanning."""
+
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "ignore")
+    return str(value)
+
+
+def compute_repo_root(start: Optional[Path] = None) -> Path:
+    root = (start or Path(__file__)).resolve()
+    for candidate in (root,) + tuple(root.parents):
+        if (candidate / "reports").exists() and (candidate / "scripts").exists():
+            return candidate
+    raise ScanError("ریشهٔ مخزن شناسایی نشد؛ ساختار reports/ و scripts/ الزامی است.")
+
+
+def compute_repo_salt(repo_root: Path) -> bytes:
+    digest = hashlib.sha256(str(repo_root).encode("utf-8")).digest()
+    return digest
+
+
+def mask_secret(value: str, repo_root: Path) -> str:
+    normalized = sanitize_text(value)
+    secret = normalized.encode("utf-8")
+    salt = compute_repo_salt(repo_root)
+    digest = hmac.new(salt, secret, hashlib.sha256).hexdigest()
+    return digest[:32]
+
+
+def normalize_variants(text: str) -> dict[str, str]:
+    sanitized = sanitize_text(text)
+    return {
+        "raw": text,
+        "sanitized": sanitized,
+        "phone": sanitize_phone(text),
+    }
+
+
+def iter_sensitive_tokens(text: str) -> Iterator[Tuple[str, str]]:
+    variants = normalize_variants(coerce_to_text(text))
+    for pattern in PATTERNS:
+        haystack = variants[pattern.variant]
+        for match in pattern.regex.finditer(haystack):
+            yield (pattern.name, match.group(0))
+
+
+def iter_candidate_files(repo_root: Path) -> Iterator[Path]:
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part in EXCLUDE_DIRS for part in path.parts):
+            continue
+        if path.suffix.lower() not in SCAN_EXTENSIONS:
+            continue
+        yield path
+
+
+def scan_file(path: Path, repo_root: Path) -> List[Finding]:
+    findings: List[Finding] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for idx, line in enumerate(handle, 1):
+                for kind, value in iter_sensitive_tokens(line):
+                    findings.append(
+                        Finding(
+                            file=path.relative_to(repo_root),
+                            line=idx,
+                            kind=kind,
+                            masked=mask_secret(value, repo_root),
+                        )
+                    )
+    except OSError as exc:  # pragma: no cover - خطاهای فایل نادر
+        raise ScanError(f"خواندن فایل {path} با خطا مواجه شد: {exc}") from exc
+    return findings
+
+
+def scan_repository(repo_root: Path, files: Optional[Sequence[Path]] = None) -> List[Finding]:
+    repo_root = repo_root.resolve()
+    candidates = files if files is not None else list(iter_candidate_files(repo_root))
+    findings: List[Finding] = []
+    for file_path in candidates:
+        absolute = file_path if file_path.is_absolute() else repo_root / file_path
+        findings.extend(scan_file(absolute, repo_root))
+    findings.sort(key=lambda item: (str(item.file), item.line, item.kind, item.masked))
+    return findings
+
+
+def ensure_reports_dir(repo_root: Path) -> Path:
+    reports_dir = repo_root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    return reports_dir
+
+
+def atomic_write_report(repo_root: Path, findings: Sequence[Finding]) -> Path:
+    reports_dir = ensure_reports_dir(repo_root)
+    target = reports_dir / "pii-scan.json"
+    payload = {
+        "findings": [
+            {
+                "file": str(item.file).replace(os.sep, "/"),
+                "kind": item.kind,
+                "line": item.line,
+                "masked": item.masked,
+            }
+            for item in findings
+        ]
+    }
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    tmp_path = target.with_suffix(".json.part")
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        handle.write(serialized)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, target)
+    return target
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="اسکن مخزن برای داده‌های حساس")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="مسیرهای سفارشی برای اسکن؛ در صورت خالی بودن کل مخزن بررسی می‌شود.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="ریشهٔ مخزن (به طور پیش‌فرض به صورت خودکار تشخیص داده می‌شود).",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: Optional[Sequence[str]] = None) -> int:
+    try:
+        args = parse_args(argv)
+        repo_root = compute_repo_root(args.repo_root)
+        if args.paths:
+            files = [Path(arg) for arg in args.paths]
+        else:
+            files = None
+        findings = scan_repository(repo_root, files)
+        atomic_write_report(repo_root, findings)
+    except ScanError as exc:
+        print(f"خطای اسکن دادهٔ حساس: {exc}")
+        return 2
+    if findings:
+        print("🚫 دادهٔ حساس شناسایی شد؛ گزارش در reports/pii-scan.json موجود است.")
+        return 1
+    print("✅ هیچ دادهٔ حساس یافت نشد؛ گزارش خالی ذخیره شد.")
+    return 0
+
+
+def main() -> int:  # pragma: no cover - نقطهٔ ورود اسکریپت
+    return run()
+
+
+if __name__ == "__main__":  # pragma: no cover - اجرای مستقیم
+    raise SystemExit(main())

--- a/tests/security/test_pii_scan.py
+++ b/tests/security/test_pii_scan.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Callable, Optional
+from uuid import uuid4
+
+import pytest
+from unittest.mock import patch
+
+from scripts.ci_no_pii_scan import (
+    Finding,
+    atomic_write_report,
+    coerce_to_text,
+    compute_repo_salt,
+    iter_sensitive_tokens,
+    mask_secret,
+    scan_repository,
+)
+
+
+@pytest.fixture
+def pii_scan_sandbox(tmp_path, monkeypatch):
+    unique_root = tmp_path / f"repo_{uuid4().hex}"
+    (unique_root / "scripts").mkdir(parents=True)
+    (unique_root / "reports").mkdir()
+    monkeypatch.chdir(unique_root)
+    yield unique_root
+    report_path = unique_root / "reports" / "pii-scan.json"
+    if report_path.exists():
+        report_path.unlink()
+
+
+def _retry_with_backoff(operation: Callable[[], Optional[list[Finding]]], *, seed: str) -> list[Finding]:
+    base_delay = 0.01
+    rng = random.Random(seed)
+    last_error: Optional[AssertionError] = None
+    for attempt in range(1, 4):
+        try:
+            result = operation()
+            if result is None:
+                raise AssertionError("عملیات نتیجه‌ای بازنگرداند.")
+            return result
+        except AssertionError as exc:  # pragma: no cover - مسیر خطا فقط در شکست تست
+            last_error = exc
+            jitter = rng.random() * 0.005
+            time.sleep(base_delay * (2 ** (attempt - 1)) + jitter)
+    if last_error is not None:
+        raise last_error
+    raise AssertionError("بازگشت بدون نتیجه")
+
+
+def _debug_context(root: Path) -> str:
+    return json.dumps(
+        {
+            "cwd": os.getcwd(),
+            "files": sorted(str(p) for p in root.rglob("*")),
+            "timestamp": 1234567890,
+        },
+        ensure_ascii=False,
+    )
+
+
+@pytest.mark.usefixtures("pii_scan_sandbox")
+def test_pii_scan_handles_edge_inputs_without_leaking(pii_scan_sandbox: Path) -> None:
+    sandbox_root = pii_scan_sandbox
+    logs_dir = sandbox_root / "logs"
+    logs_dir.mkdir()
+    sample_log = logs_dir / f"sample_{uuid4().hex}.log"
+    long_text = "الف" * 100_000
+    zero_width_mobile = "\u200c۰۹۱۲۳۴۵۶۷۸۹"
+    persian_mobile = "۰۹۱۲۳۴۵۶۷۸۹"
+    national_id = "1234567890"
+    sample_log.write_text(
+        "\n".join(
+            [
+                coerce_to_text(None),
+                coerce_to_text(0),
+                coerce_to_text("0"),
+                long_text,
+                zero_width_mobile,
+                persian_mobile,
+                national_id,
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    massive_file = logs_dir / f"massive_{uuid4().hex}.txt"
+    massive_file.write_text("الف" * 1_000_000, encoding="utf-8")
+
+    def operation() -> list[Finding]:
+        findings = scan_repository(
+            sandbox_root,
+            [
+                sample_log.relative_to(sandbox_root),
+                massive_file.relative_to(sandbox_root),
+            ],
+        )
+        atomic_write_report(sandbox_root, findings)
+        return findings
+
+    with patch("time.time", return_value=1711111111.0), patch("time.sleep", lambda *_: None):
+        findings = _retry_with_backoff(operation, seed="pii-scan")
+
+    context = _debug_context(sandbox_root)
+
+    evidence_mobile = [f for f in findings if f.kind == "mobile"]
+    evidence_national = [f for f in findings if f.kind == "national_id"]
+
+    assert evidence_mobile, f"موبایل شناسایی نشد: {context}"
+    assert evidence_national, f"کدملی شناسایی نشد: {context}"
+
+    for finding in findings:
+        assert len(finding.masked) == 32, f"طول ماسک اشتباه است: {context}"
+        assert finding.masked.isalnum(), f"حروف ماسک معتبر نیست: {context}"
+
+    report_path = sandbox_root / "reports" / "pii-scan.json"
+    with report_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    assert payload["findings"], f"گزارش خالی است: {context}"
+    for entry in payload["findings"]:
+        assert "masked" in entry, f"کلید ماسک وجود ندارد: {context}"
+        assert entry["masked"] not in {persian_mobile, national_id}, f"افشای داده رخ داد: {context}"
+
+    for value in (None, 0, "0", "", "۰۱۲۳", "٠٩١٢٣٤٥٦٧٨٩"):
+        coerced = coerce_to_text(value)
+        tokens = list(iter_sensitive_tokens(coerced))
+        assert all(token[1] != coerced for token in tokens), f"ورودی ساده نباید افشا شود: {context}"
+
+    salt = compute_repo_salt(sandbox_root)
+    expected_mask = mask_secret("09123456789", sandbox_root)
+    assert expected_mask == mask_secret("۰۹۱۲۳۴۵۶۷۸۹", sandbox_root), f"نرمال‌سازی موبایل نادرست است: {context}"
+    assert salt == compute_repo_salt(sandbox_root), f"نمک باید دترمینیستیک باشد: {context}"


### PR DESCRIPTION
## Summary
- add a deterministic HMAC-based PII scanner that writes reports atomically and exits on sensitive findings
- wire the new `pii-scan` target into the Makefile and run it in GitHub Actions and GitLab CI prior to the existing gates
- cover sanitization edge cases with a security regression test that exercises normalization, retries, and large-file handling

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=/workspace/student-mentor-allocation-system pytest tests/security/test_pii_scan.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9290049bc8321bde05ba75382b9d1