### PR TITLE
Finalize Phase-5 reliability evidence artifacts

### DIFF
--- a/dr/run.py
+++ b/dr/run.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from src.reliability import DisasterRecoveryDrill, ReliabilityMetrics, ReliabilitySettings
+from src.reliability.logging_utils import JSONLogger, configure_logging
+
+app = typer.Typer(help="Disaster recovery drill runner.")
+
+
+def _load_settings(config_path: Path) -> ReliabilitySettings:
+    content = config_path.read_text(encoding="utf-8")
+    return ReliabilitySettings.model_validate_json(content)
+
+
+@app.command()
+def rehearsal(
+    config: Path = typer.Argument(..., help="Path to reliability settings JSON."),
+    source: Path = typer.Option(Path("artifacts"), help="Source directory for backup."),
+    destination: Path = typer.Option(Path("tmp/restore"), help="Destination for restore."),
+    correlation_id: str = typer.Option("dr-cli", help="Correlation identifier."),
+    report_path: Path = typer.Option(Path("dr/rehearsal_report.json"), help="Report path."),
+) -> None:
+    settings = _load_settings(config)
+    configure_logging()
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("reliability.dr")
+    clock = settings.build_clock()
+    drill = DisasterRecoveryDrill(
+        backups_root=settings.backups_root,
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        report_path=report_path,
+    )
+    drill.run(
+        source,
+        destination,
+        correlation_id=correlation_id,
+        namespace=settings.redis.namespace,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/ops/cleanupd.py
+++ b/ops/cleanupd.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from src.reliability import CleanupDaemon, ReliabilityMetrics, ReliabilitySettings
+from src.reliability.logging_utils import JSONLogger, configure_logging
+
+app = typer.Typer(help="Cleanup daemon for .part files and expired links.")
+
+
+def _load_settings(config_path: Path) -> ReliabilitySettings:
+    content = config_path.read_text(encoding="utf-8")
+    return ReliabilitySettings.model_validate_json(content)
+
+
+@app.command()
+def run(
+    config: Path = typer.Argument(..., help="Path to reliability settings JSON."),
+    registry_path: Path = typer.Option(Path("artifacts/signed_urls.json"), help="Signed URL registry path."),
+    report_path: Path = typer.Option(
+        Path("reports/cleanup/report.json"), help="Cleanup report destination."
+    ),
+) -> None:
+    settings = _load_settings(config)
+    configure_logging()
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("reliability.cleanup")
+    clock = settings.build_clock()
+    daemon = CleanupDaemon(
+        artifacts_root=settings.artifacts_root,
+        backups_root=settings.backups_root,
+        config=settings.cleanup,
+        metrics=metrics,
+        clock=clock,
+        logger=logger,
+        registry_path=registry_path,
+        namespace=settings.redis.namespace,
+        report_path=report_path,
+    )
+    daemon.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/ops/retention_enforcer.py
+++ b/ops/retention_enforcer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from src.reliability import ReliabilityMetrics, ReliabilitySettings, RetentionEnforcer
+from src.reliability.logging_utils import JSONLogger, configure_logging
+
+app = typer.Typer(help="Retention enforcer (dry-run then enforce).")
+
+
+def _load_settings(config_path: Path) -> ReliabilitySettings:
+    content = config_path.read_text(encoding="utf-8")
+    return ReliabilitySettings.model_validate_json(content)
+
+
+@app.command()
+def run(
+    config: Path = typer.Argument(..., help="Path to reliability settings JSON."),
+    report_path: Path = typer.Option(Path("reports/retention/report.json"), help="Report destination."),
+    csv_report_path: Path = typer.Option(
+        Path("reports/retention/report.csv"), help="CSV evidence destination."
+    ),
+) -> None:
+    settings = _load_settings(config)
+    configure_logging()
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("reliability.retention")
+    clock = settings.build_clock()
+    enforcer = RetentionEnforcer(
+        artifacts_root=settings.artifacts_root,
+        backups_root=settings.backups_root,
+        config=settings.retention,
+        metrics=metrics,
+        clock=clock,
+        logger=logger,
+        report_path=report_path,
+        csv_report_path=csv_report_path,
+        namespace=settings.redis.namespace,
+    )
+    enforcer.run(enforce=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/reliability/__init__.py
+++ b/src/reliability/__init__.py
@@ -1,0 +1,30 @@
+"""Reliability engineering toolkit for disaster recovery and chaos testing."""
+from __future__ import annotations
+
+from .clock import Clock
+from .config import ReliabilitySettings
+from .chaos import (
+    DbConnectionResetInjector,
+    PostgresConnectionResetScenario,
+    RedisFlapInjector,
+    RedisFlapScenario,
+)
+from .drill import DisasterRecoveryDrill
+from .retention import RetentionEnforcer
+from .cleanup import CleanupDaemon
+from .metrics import ReliabilityMetrics
+from .http_app import create_reliability_app
+
+__all__ = [
+    "Clock",
+    "ReliabilitySettings",
+    "RedisFlapScenario",
+    "PostgresConnectionResetScenario",
+    "RedisFlapInjector",
+    "DbConnectionResetInjector",
+    "DisasterRecoveryDrill",
+    "RetentionEnforcer",
+    "CleanupDaemon",
+    "ReliabilityMetrics",
+    "create_reliability_app",
+]

--- a/src/reliability/atomic.py
+++ b/src/reliability/atomic.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_text(path: str | Path, data: str, *, encoding: str = "utf-8") -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp = destination.with_suffix(destination.suffix + ".part")
+    with tmp.open("w", encoding=encoding) as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, destination)
+
+
+def atomic_write_json(path: str | Path, data: Any) -> None:
+    payload = json.dumps(data, ensure_ascii=False, indent=2)
+    atomic_write_text(path, payload)
+
+
+def atomic_write_bytes(path: str | Path, data: bytes) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp = destination.with_suffix(destination.suffix + ".part")
+    with tmp.open("wb") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, destination)
+
+
+__all__ = ["atomic_write_json", "atomic_write_text", "atomic_write_bytes"]

--- a/src/reliability/chaos.py
+++ b/src/reliability/chaos.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from hashlib import blake2b
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+from tenacity import Retrying, RetryError, RetryCallState, retry_if_exception_type, stop_after_attempt
+from tenacity.wait import wait_base
+
+from .atomic import atomic_write_json
+from .clock import Clock
+from .logging_utils import JSONLogger, persian_error
+from .metrics import ReliabilityMetrics
+
+
+class DeterministicWait(wait_base):
+    def __init__(self, base: float, cap: float, jitter: float, seed: str) -> None:
+        self.base = base
+        self.cap = cap
+        self.jitter = jitter
+        self.seed = seed
+
+    def __call__(self, retry_state: "RetryCallState") -> float:
+        attempt = max(1, retry_state.attempt_number)
+        backoff = min(self.cap, self.base * (2 ** (attempt - 1)))
+        fingerprint = blake2b(f"{self.seed}:{attempt}".encode("utf-8"), digest_size=8).digest()
+        jitter_fraction = int.from_bytes(fingerprint, "big") / float(1 << (8 * len(fingerprint)))
+        jitter = jitter_fraction * self.jitter
+        return backoff + jitter
+
+
+class ChaosInjectionError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class ChaosContext:
+    scenario: str
+    correlation_id: str
+    namespace: str
+
+
+class ChaosScenario:
+    def __init__(
+        self,
+        *,
+        name: str,
+        metrics: ReliabilityMetrics,
+        logger: JSONLogger,
+        clock: Clock,
+        reports_root: Path,
+        max_attempts: int = 5,
+        base_backoff: float = 0.05,
+        max_backoff: float = 1.0,
+        jitter: float = 0.02,
+        sleeper: Callable[[float], None] | None = None,
+    ) -> None:
+        self.name = name
+        self.metrics = metrics
+        self._logger = logger
+        self.clock = clock
+        self.reports_root = Path(reports_root)
+        self.max_attempts = max_attempts
+        self.base_backoff = base_backoff
+        self.max_backoff = max_backoff
+        self.jitter = jitter
+        self.sleeper = sleeper or (lambda _: None)
+
+    def _retrying(self, correlation_id: str) -> Retrying:
+        wait_strategy = DeterministicWait(
+            base=self.base_backoff,
+            cap=self.max_backoff,
+            jitter=self.jitter,
+            seed=correlation_id,
+        )
+        return Retrying(
+            stop=stop_after_attempt(self.max_attempts),
+            wait=wait_strategy,
+            sleep=self.sleeper,
+            retry=retry_if_exception_type((ChaosInjectionError, ConnectionError)),
+            reraise=True,
+        )
+
+    def run(
+        self,
+        operation: Callable[[], object],
+        *,
+        fault_plan: Sequence[int] | Iterable[int] | None = None,
+        correlation_id: str | None = None,
+        namespace: str = "default",
+    ) -> dict[str, object]:
+        corr = correlation_id or uuid.uuid4().hex
+        logger = self._logger.bind(corr)
+        plan = list(fault_plan or ())
+        retrying = self._retrying(corr)
+        attempts = 0
+        injected = 0
+        last_error: str | None = None
+        start = self.clock.now()
+        try:
+            for attempt in retrying:
+                attempts = attempt.retry_state.attempt_number
+                with attempt:
+                    if attempts <= len(plan) and plan[attempts - 1]:
+                        injected += 1
+                        last_error = "Injected fault"
+                        self.metrics.mark_chaos(
+                            scenario=self.name,
+                            incident_type=self._incident_type,
+                            outcome="fault",
+                            reason="injected_fault",
+                            namespace=namespace,
+                        )
+                        self.metrics.mark_retry(
+                            operation=f"chaos:{self.name}",
+                            namespace=namespace,
+                        )
+                        logger.warning(
+                            f"chaos.retry.{self.name}",
+                            attempt=attempts,
+                            last_error=last_error,
+                            namespace=namespace,
+                            plan_index=attempts - 1,
+                        )
+                        raise ChaosInjectionError(last_error)
+                    try:
+                        result = operation()
+                    except ConnectionError as exc:
+                        last_error = str(exc)
+                        self.metrics.mark_retry(
+                            operation=f"chaos:{self.name}",
+                            namespace=namespace,
+                        )
+                        logger.warning(
+                            f"chaos.retry.{self.name}",
+                            attempt=attempts,
+                            last_error=last_error,
+                            namespace=namespace,
+                            plan_index=attempts - 1,
+                        )
+                        raise
+                    self.metrics.mark_chaos(
+                        scenario=self.name,
+                        incident_type=self._incident_type,
+                        outcome="success",
+                        reason="completed",
+                        namespace=namespace,
+                    )
+                    self.metrics.mark_operation(
+                        operation=f"chaos:{self.name}",
+                        outcome="success",
+                        reason="completed",
+                        namespace=namespace,
+                    )
+                    report = self._build_report(
+                        attempts=attempts,
+                        injected=injected,
+                        success=True,
+                        last_error=None,
+                        start=start,
+                        namespace=namespace,
+                    )
+                    if result is not None:
+                        report["result"] = result
+                    self._write_report(report)
+                    return report
+        except RetryError as err:
+            last_error = str(err)
+            self.metrics.mark_exhausted(
+                operation=f"chaos:{self.name}", namespace=namespace
+            )
+            self.metrics.mark_operation(
+                operation=f"chaos:{self.name}",
+                outcome="failure",
+                reason="exhausted",
+                namespace=namespace,
+            )
+            logger.error(
+                f"chaos.exhausted.{self.name}",
+                attempts=attempts,
+                last_error=last_error,
+                namespace=namespace,
+            )
+            report = self._build_report(
+                attempts=attempts,
+                injected=injected,
+                success=False,
+                last_error=last_error,
+                start=start,
+                namespace=namespace,
+            )
+            self._write_report(report)
+            raise RuntimeError(
+                persian_error(
+                    "آزمایش آشوب در نهایت موفق نشد؛ لطفاً دوباره تلاش کنید.",
+                    "CHAOS_FAILURE",
+                    correlation_id=corr,
+                        )
+                )
+        report = self._build_report(
+            attempts=attempts,
+            injected=injected,
+            success=False,
+            last_error=last_error,
+            start=start,
+            namespace=namespace,
+        )
+        self._write_report(report)
+        return report
+
+    @property
+    def _incident_type(self) -> str:
+        return "redis" if isinstance(self, RedisFlapScenario) else "postgres"
+
+    def _build_report(
+        self,
+        *,
+        attempts: int,
+        injected: int,
+        success: bool,
+        last_error: str | None,
+        start: object,
+        namespace: str,
+    ) -> dict[str, object]:
+        end = self.clock.now()
+        duration = max(0.0, (end - start).total_seconds())
+        return {
+            "scenario": self.name,
+            "attempts": attempts,
+            "injected": injected,
+            "success": success,
+            "last_error": last_error,
+            "started_at": getattr(start, "isoformat", lambda: str(start))(),
+            "ended_at": end.isoformat(),
+            "duration_s": duration,
+            "namespace": namespace,
+        }
+
+    def _write_report(self, report: dict[str, object]) -> None:
+        destination = self.reports_root / f"{self.name}.json"
+        atomic_write_json(destination, report)
+
+
+class RedisFlapScenario(ChaosScenario):
+    pass
+
+
+class PostgresConnectionResetScenario(ChaosScenario):
+    pass
+
+
+class RedisFlapInjector(RedisFlapScenario):
+    """Backwards compatible alias emphasising injector semantics."""
+
+
+class DbConnectionResetInjector(PostgresConnectionResetScenario):
+    """Backwards compatible alias emphasising injector semantics."""
+
+
+__all__ = [
+    "RedisFlapScenario",
+    "PostgresConnectionResetScenario",
+    "RedisFlapInjector",
+    "DbConnectionResetInjector",
+    "ChaosInjectionError",
+]

--- a/src/reliability/cleanup.py
+++ b/src/reliability/cleanup.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+from .atomic import atomic_write_json
+from .clock import Clock
+from .config import CleanupConfig
+from .logging_utils import JSONLogger
+from .metrics import ReliabilityMetrics
+
+
+@dataclass(slots=True)
+class CleanupResult:
+    removed_part_files: List[str]
+    removed_links: List[str]
+
+
+class CleanupDaemon:
+    def __init__(
+        self,
+        *,
+        artifacts_root: Path,
+        backups_root: Path,
+        config: CleanupConfig,
+        metrics: ReliabilityMetrics,
+        clock: Clock,
+        logger: JSONLogger,
+        registry_path: Path | None = None,
+        namespace: str = "default",
+        report_path: Path | None = None,
+    ) -> None:
+        self.artifacts_root = Path(artifacts_root)
+        self.backups_root = Path(backups_root)
+        self.config = config
+        self.metrics = metrics
+        self.clock = clock
+        self.logger = logger
+        self.registry_path = Path(registry_path) if registry_path else self.artifacts_root / "signed_urls.json"
+        self.namespace = namespace or "default"
+        self.report_path = Path(report_path) if report_path else None
+
+    def run(self) -> CleanupResult:
+        removed_parts = self._cleanup_part_files()
+        removed_links = self._cleanup_links()
+        reason = "completed"
+        if not removed_parts and not removed_links:
+            reason = "no_action"
+        self.metrics.mark_operation(
+            operation="cleanup",
+            outcome="success",
+            reason=reason,
+            namespace=self.namespace,
+        )
+        result = CleanupResult(removed_part_files=removed_parts, removed_links=removed_links)
+        self._write_report(result, reason=reason)
+        return result
+
+    def _cleanup_part_files(self) -> List[str]:
+        removed: List[str] = []
+        cutoff = self.clock.now().timestamp() - self.config.part_max_age
+        for root in (self.artifacts_root, self.backups_root):
+            if not root.exists():
+                continue
+            for path in root.rglob("*.part"):
+                try:
+                    if path.stat().st_mtime <= cutoff:
+                        path.unlink(missing_ok=True)
+                        removed.append(str(path))
+                        self.metrics.mark_cleanup(kind="part_file", namespace=self.namespace)
+                        self.logger.bind("cleanup-part").info(
+                            "cleanup.removed_part",
+                            path=str(path),
+                        )
+                except OSError:
+                    continue
+        return removed
+
+    def _cleanup_links(self) -> List[str]:
+        registry = self._load_registry()
+        now = self.clock.now().timestamp()
+        kept: Dict[str, dict] = {}
+        removed: List[str] = []
+        for key, payload in registry.items():
+            expires_at = float(payload.get("expires_at") or 0)
+            created_at = float(payload.get("created_at") or 0)
+            ttl_expired = created_at and (created_at + self.config.link_ttl <= now)
+            expires_expired = expires_at and expires_at <= now
+            if ttl_expired or expires_expired:
+                removed.append(key)
+                self.metrics.mark_cleanup(kind="signed_url", namespace=self.namespace)
+                self.logger.bind("cleanup-link").info(
+                    "cleanup.removed_link",
+                    token=key,
+                )
+            else:
+                kept[key] = payload
+        if self.registry_path:
+            atomic_write_json(self.registry_path, kept)
+        return removed
+
+    def _load_registry(self) -> Dict[str, dict]:
+        if not self.registry_path or not self.registry_path.exists():
+            return {}
+        try:
+            with self.registry_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                if isinstance(data, dict):
+                    return {str(k): dict(v) for k, v in data.items() if isinstance(v, dict)}
+        except json.JSONDecodeError:
+            return {}
+        return {}
+
+    def _write_report(self, result: CleanupResult, *, reason: str) -> None:
+        if not self.report_path:
+            return
+        payload = {
+            "timestamp": self.clock.now().isoformat(),
+            "namespace": self.namespace,
+            "reason": reason,
+            "removed_part_files": result.removed_part_files,
+            "removed_links": result.removed_links,
+        }
+        atomic_write_json(self.report_path, payload)
+
+
+__all__ = ["CleanupDaemon", "CleanupResult"]

--- a/src/reliability/clock.py
+++ b/src/reliability/clock.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from typing import Callable
+from zoneinfo import ZoneInfo
+
+
+def _utc_now() -> _dt.datetime:
+    return _dt.datetime.now(_dt.UTC)
+
+
+@dataclass(slots=True)
+class Clock:
+    """Deterministic clock with injectable time source."""
+
+    timezone: ZoneInfo
+    _now_factory: Callable[[], _dt.datetime] = _utc_now
+
+    def now(self) -> _dt.datetime:
+        """Return an aware datetime using the configured timezone."""
+
+        current = self._now_factory()
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=_dt.timezone.utc)
+        return current.astimezone(self.timezone)
+
+    def isoformat(self) -> str:
+        return self.now().isoformat()
+
+    def measure(self, func: Callable[[], object]) -> tuple[object, float]:
+        """Execute *func* returning elapsed seconds using the injected clock."""
+
+        start = self.now()
+        result = func()
+        end = self.now()
+        elapsed = (end - start).total_seconds()
+        return result, max(0.0, elapsed)
+
+
+__all__ = ["Clock"]

--- a/src/reliability/config.py
+++ b/src/reliability/config.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from zoneinfo import ZoneInfo
+
+ZERO_WIDTH_RE = re.compile("[\u200b-\u200d\u202a-\u202e\ufeff\u2060]")
+FA_AR_DIGIT_MAP = str.maketrans({**{chr(0x06F0 + i): str(i) for i in range(10)}, **{chr(0x0660 + i): str(i) for i in range(10)}})
+
+
+def _normalise_string(value: Any) -> Any:
+    if isinstance(value, str):
+        cleaned = ZERO_WIDTH_RE.sub("", value).translate(FA_AR_DIGIT_MAP).strip()
+        return cleaned
+    return value
+
+
+class RedisConfig(BaseModel):
+    model_config = SettingsConfigDict(extra="forbid")
+
+    dsn: str = Field(min_length=1)
+    namespace: str = Field(default="reliability")
+
+    @field_validator("dsn", "namespace", mode="before")
+    @classmethod
+    def _clean(cls, value: Any) -> Any:
+        return _normalise_string(value)
+
+
+class PostgresConfig(BaseModel):
+    model_config = SettingsConfigDict(extra="forbid")
+
+    read_write_dsn: str = Field(min_length=1)
+    replica_dsn: str = Field(min_length=1)
+
+    @field_validator("read_write_dsn", "replica_dsn", mode="before")
+    @classmethod
+    def _clean(cls, value: Any) -> Any:
+        return _normalise_string(value)
+
+
+class RetentionConfig(BaseModel):
+    age_days: int = Field(ge=0)
+    max_total_bytes: int = Field(ge=0)
+
+
+class CleanupConfig(BaseModel):
+    part_max_age: int = Field(ge=0, description="Maximum age in seconds for .part files")
+    link_ttl: int = Field(ge=0, description="TTL in seconds for signed URLs")
+
+
+class TokenConfig(BaseModel):
+    model_config = SettingsConfigDict(extra="forbid")
+
+    metrics_read: str = Field(min_length=8)
+
+    @field_validator("metrics_read", mode="before")
+    @classmethod
+    def _clean(cls, value: Any) -> Any:
+        return _normalise_string(value)
+
+
+class IdempotencyConfig(BaseModel):
+    ttl_seconds: int = Field(ge=0, default=24 * 3600)
+    storage_prefix: str = Field(default="idem")
+
+
+class RateLimitRuleModel(BaseModel):
+    requests: int = Field(gt=0)
+    window_seconds: float = Field(gt=0)
+
+
+class RateLimitConfigModel(BaseModel):
+    model_config = SettingsConfigDict(extra="forbid")
+
+    default_rule: RateLimitRuleModel
+    fail_open: bool = False
+
+
+class ReliabilitySettings(BaseSettings):
+    """Typed settings for reliability and disaster recovery tooling."""
+
+    model_config = SettingsConfigDict(extra="forbid")
+
+    redis: RedisConfig
+    postgres: PostgresConfig
+    artifacts_root: Path
+    backups_root: Path
+    retention: RetentionConfig
+    cleanup: CleanupConfig
+    tokens: TokenConfig
+    timezone: str = Field(default="Asia/Baku")
+    rate_limit: RateLimitConfigModel
+    idempotency: IdempotencyConfig = Field(default_factory=IdempotencyConfig)
+
+    @field_validator("artifacts_root", "backups_root", mode="before")
+    @classmethod
+    def _ensure_path(cls, value: str | Path) -> Path:
+        if isinstance(value, Path):
+            return value
+        return Path(value)
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, value: str) -> str:
+        cleaned = _normalise_string(value)
+        try:
+            ZoneInfo(cleaned)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown timezone: {value}") from exc
+        return cleaned
+
+    def clock(self) -> ZoneInfo:
+        return ZoneInfo(self.timezone)
+
+    def build_clock(self, now_factory: Callable[[], Any] | None = None) -> "Clock":
+        from .clock import Clock
+
+        if now_factory is None:
+            return Clock(self.clock())
+        return Clock(self.clock(), now_factory)
+
+
+__all__ = ["ReliabilitySettings", "RedisConfig", "PostgresConfig", "RetentionConfig", "CleanupConfig"]

--- a/src/reliability/drill.py
+++ b/src/reliability/drill.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import blake2b
+from pathlib import Path
+from typing import List, Sequence
+
+from .atomic import atomic_write_json
+from .clock import Clock
+from .logging_utils import JSONLogger, persian_error
+from .metrics import ReliabilityMetrics
+
+
+@dataclass(slots=True)
+class BackupEntry:
+    path: Path
+    sha256: str
+    size_bytes: int
+    modified_at: float
+
+
+@dataclass(slots=True)
+class BackupResult:
+    run_id: str
+    started_at: str
+    completed_at: str
+    entries: Sequence[BackupEntry]
+    total_bytes: int
+
+
+@dataclass(slots=True)
+class RestoreResult:
+    started_at: str
+    completed_at: str
+    duration_s: float
+    rpo_s: float
+    verified: bool
+    restored_bytes: int
+
+
+def _derive_run_id(namespace: str, idempotency_key: str, tick_ms: int) -> str:
+    payload = f"{namespace}|{idempotency_key}|{tick_ms}".encode("utf-8", "ignore")
+    return blake2b(payload, digest_size=16).hexdigest()
+
+
+class DisasterRecoveryDrill:
+    def __init__(
+        self,
+        *,
+        backups_root: Path,
+        metrics: ReliabilityMetrics,
+        logger: JSONLogger,
+        clock: Clock,
+        report_path: Path,
+    ) -> None:
+        self.backups_root = Path(backups_root)
+        self.metrics = metrics
+        self.logger = logger
+        self.clock = clock
+        self.report_path = Path(report_path)
+
+    def run(
+        self,
+        source: Path,
+        destination: Path,
+        *,
+        correlation_id: str,
+        namespace: str = "default",
+        idempotency_key: str | None = None,
+    ) -> dict[str, object]:
+        source = Path(source)
+        destination = Path(destination)
+        idem = (idempotency_key or correlation_id or "drill").strip() or "drill"
+        start_instant = self.clock.now()
+        tick_ms = int(max(0, start_instant.timestamp() * 1000))
+        run_id = _derive_run_id(namespace, idem, tick_ms)
+        backup_dir = self.backups_root / run_id
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics.inflight_backups.inc()
+        try:
+            backup_result = self._perform_backup(
+                source,
+                backup_dir,
+                namespace=namespace,
+                started_at=start_instant,
+            )
+        finally:
+            self.metrics.inflight_backups.dec()
+        restore_result = self._perform_restore(
+            backup_result,
+            destination,
+            namespace=namespace,
+        )
+        report = {
+            "correlation_id": correlation_id,
+            "run_id": run_id,
+            "started_at": backup_result.started_at,
+            "ended_at": restore_result.completed_at,
+            "duration_s": max(
+                0.0,
+                self._seconds_between(backup_result.started_at, restore_result.completed_at),
+            ),
+            "rto_s": restore_result.duration_s,
+            "rpo_s": restore_result.rpo_s,
+            "rto_ms": int(round(restore_result.duration_s * 1000)),
+            "rpo_ms": int(round(restore_result.rpo_s * 1000)),
+            "sha256": [
+                {
+                    "path": str(entry.path),
+                    "sha256": entry.sha256,
+                    "size_bytes": entry.size_bytes,
+                }
+                for entry in backup_result.entries
+            ],
+            "restored_bytes": restore_result.restored_bytes,
+            "backed_up_bytes": backup_result.total_bytes,
+        }
+        atomic_write_json(self.report_path, report)
+        self.metrics.mark_dr(status="success", namespace=namespace)
+        self.metrics.mark_operation(
+            operation="drill",
+            outcome="success",
+            reason="completed",
+            namespace=namespace,
+        )
+        self.logger.bind(correlation_id).info(
+            "dr.completed",
+            report=report,
+        )
+        return report
+
+    def _perform_backup(
+        self,
+        source: Path,
+        destination: Path,
+        *,
+        namespace: str,
+        started_at: datetime | None = None,
+    ) -> BackupResult:
+        start_dt = started_at or self.clock.now()
+        entries: List[BackupEntry] = []
+        total_bytes = 0
+        for file_path in sorted(source.rglob("*")):
+            if not file_path.is_file():
+                continue
+            rel = file_path.relative_to(source)
+            target = destination / rel
+            sha = hashlib.sha256()
+            size = 0
+            target.parent.mkdir(parents=True, exist_ok=True)
+            tmp = target.with_suffix(target.suffix + ".part")
+            with file_path.open("rb") as src, tmp.open("wb") as dst:
+                for chunk in iter(lambda: src.read(1024 * 1024), b""):
+                    sha.update(chunk)
+                    dst.write(chunk)
+                    size += len(chunk)
+                dst.flush()
+                os.fsync(dst.fileno())
+            os.replace(tmp, target)
+            entry = BackupEntry(
+                path=rel,
+                sha256=sha.hexdigest(),
+                size_bytes=size,
+                modified_at=file_path.stat().st_mtime,
+            )
+            entries.append(entry)
+            total_bytes += size
+            self.metrics.add_dr_bytes(direction="backup", amount=size, namespace=namespace)
+        end_dt = self.clock.now()
+        result = BackupResult(
+            run_id=destination.name,
+            started_at=start_dt.isoformat(),
+            completed_at=end_dt.isoformat(),
+            entries=tuple(entries),
+            total_bytes=total_bytes,
+        )
+        self.metrics.observe_duration("dr.backup", (end_dt - start_dt).total_seconds())
+        return result
+
+    def _perform_restore(
+        self,
+        backup: BackupResult,
+        destination: Path,
+        *,
+        namespace: str,
+    ) -> RestoreResult:
+        start_dt = self.clock.now()
+        restored_bytes = 0
+        verified = True
+        destination.mkdir(parents=True, exist_ok=True)
+        for entry in backup.entries:
+            source_file = self.backups_root / backup.run_id / entry.path
+            target_file = destination / entry.path
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            sha = hashlib.sha256()
+            tmp = target_file.with_suffix(target_file.suffix + ".part")
+            with source_file.open("rb") as src, tmp.open("wb") as dst:
+                for chunk in iter(lambda: src.read(1024 * 1024), b""):
+                    sha.update(chunk)
+                    dst.write(chunk)
+                dst.flush()
+                os.fsync(dst.fileno())
+            os.replace(tmp, target_file)
+            digest = sha.hexdigest()
+            restored_bytes += entry.size_bytes
+            if digest != entry.sha256:
+                verified = False
+            self.metrics.add_dr_bytes(
+                direction="restore", amount=entry.size_bytes, namespace=namespace
+            )
+        end_dt = self.clock.now()
+        duration = max(0.0, (end_dt - start_dt).total_seconds())
+        completed_at = end_dt.isoformat()
+        rpo = max(0.0, self._seconds_between(backup.completed_at, start_dt.isoformat()))
+        self.metrics.observe_duration("dr.restore", duration)
+        if not verified:
+            self.metrics.mark_dr(status="checksum_mismatch", namespace=namespace)
+            self.metrics.mark_operation(
+                operation="drill",
+                outcome="failure",
+                reason="checksum_mismatch",
+                namespace=namespace,
+            )
+            raise RuntimeError(
+                persian_error(
+                    "بازیابی پشتیبان موفق نبود؛ جمع کنترل تطابق ندارد.",
+                    "DR_SHA_MISMATCH",
+                    correlation_id=backup.run_id,
+                )
+            )
+        return RestoreResult(
+            started_at=start_dt.isoformat(),
+            completed_at=completed_at,
+            duration_s=duration,
+            rpo_s=rpo,
+            verified=verified,
+            restored_bytes=restored_bytes,
+        )
+
+    def _seconds_between(self, start_iso: str, end_iso: str) -> float:
+        from datetime import datetime
+
+        start = datetime.fromisoformat(start_iso)
+        end = datetime.fromisoformat(end_iso)
+        return (end - start).total_seconds()
+
+
+__all__ = ["DisasterRecoveryDrill"]

--- a/src/reliability/http_app.py
+++ b/src/reliability/http_app.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import secrets
+from typing import Any, Callable, Dict
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse
+from prometheus_client import generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .cleanup import CleanupDaemon
+from .clock import Clock
+from .config import IdempotencyConfig, RateLimitConfigModel, ReliabilitySettings
+from .drill import DisasterRecoveryDrill
+from .logging_utils import JSONLogger
+from .metrics import ReliabilityMetrics
+from .retention import RetentionEnforcer
+
+
+_ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _encode_ulid_component(value: int, length: int) -> str:
+    mask = (1 << (length * 5)) - 1
+    value &= mask
+    chars = ["0"] * length
+    for idx in range(length - 1, -1, -1):
+        chars[idx] = _ULID_ALPHABET[value & 0x1F]
+        value >>= 5
+    return "".join(chars)
+
+
+def _generate_ulid(clock: Clock) -> str:
+    timestamp_ms = int(max(0, clock.now().timestamp() * 1000))
+    randomness = int.from_bytes(secrets.token_bytes(10), "big")
+    return _encode_ulid_component(timestamp_ms, 10) + _encode_ulid_component(randomness, 16)
+
+
+def _resolve_correlation_id(request: Request, clock: Clock) -> str:
+    header = request.headers.get("X-Request-ID")
+    if header:
+        candidate = header.strip()
+        if candidate:
+            return candidate
+    return _generate_ulid(clock)
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, *, config: RateLimitConfigModel, clock: Clock) -> None:
+        super().__init__(app)
+        self.config = config
+        self.clock = clock
+        self._state: Dict[str, tuple[int, float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Any]) -> Response:
+        key = request.headers.get("X-RateLimit-Key") or "global"
+        now = self.clock.now().timestamp()
+        async with self._lock:
+            count, reset_at = self._state.get(key, (0, now + self.config.default_rule.window_seconds))
+            if now >= reset_at:
+                count = 0
+                reset_at = now + self.config.default_rule.window_seconds
+            limit_reached = count >= self.config.default_rule.requests
+            if limit_reached and request.method != "GET" and not self.config.fail_open:
+                raise HTTPException(status_code=429, detail="نرخ درخواست مجاز نیست.")
+            self._state[key] = (count + 1, reset_at)
+        request.state.middleware_order = getattr(request.state, "middleware_order", []) + ["RateLimit"]
+        return await call_next(request)
+
+
+class IdempotencyMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, *, config: IdempotencyConfig, clock: Clock) -> None:
+        super().__init__(app)
+        self.config = config
+        self.clock = clock
+        self._lock = asyncio.Lock()
+        self._store: Dict[str, tuple[bytes, float, Dict[str, str]]] = {}
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Any]) -> Response:
+        request.state.middleware_order = getattr(request.state, "middleware_order", []) + ["Idempotency"]
+        if request.method != "POST":
+            return await call_next(request)
+        key = request.headers.get("Idempotency-Key")
+        if not key:
+            raise HTTPException(status_code=400, detail="کلید تکرار الزامی است.")
+        now = self.clock.now().timestamp()
+        async with self._lock:
+            cached = self._store.get(key)
+            if cached and cached[1] + self.config.ttl_seconds > now:
+                body, _, headers = cached
+                response = Response(content=body, headers=headers, media_type="application/json")
+                order = getattr(request.state, "middleware_order", [])
+                if order:
+                    response.headers["X-Middleware-Order"] = ",".join(order)
+                return response
+        response = await call_next(request)
+        body = b""
+        async for chunk in response.body_iterator:
+            body += chunk
+        headers = dict(response.headers)
+        async with self._lock:
+            self._store[key] = (body, now, headers)
+        enriched = Response(
+            content=body,
+            status_code=response.status_code,
+            headers=headers,
+            media_type=response.media_type,
+        )
+        order = getattr(request.state, "middleware_order", [])
+        if order:
+            enriched.headers["X-Middleware-Order"] = ",".join(order)
+        return enriched
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, *, token: str) -> None:
+        super().__init__(app)
+        self.token = token
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Any]) -> Response:
+        request.state.middleware_order = getattr(request.state, "middleware_order", []) + ["Auth"]
+        if request.method != "GET":
+            header = request.headers.get("Authorization")
+            if header != f"Bearer {self.token}":
+                raise HTTPException(status_code=401, detail="دسترسی مجاز نیست.")
+        response = await call_next(request)
+        order = getattr(request.state, "middleware_order", [])
+        if order:
+            response.headers["X-Middleware-Order"] = ",".join(order)
+        return response
+
+
+def create_reliability_app(
+    *,
+    settings: ReliabilitySettings,
+    metrics: ReliabilityMetrics,
+    retention: RetentionEnforcer,
+    cleanup: CleanupDaemon,
+    drill: DisasterRecoveryDrill,
+    logger: JSONLogger,
+    clock: Clock,
+) -> FastAPI:
+    app = FastAPI()
+
+    # Register in reverse so execution order becomes RateLimit -> Idempotency -> Auth
+    app.add_middleware(AuthMiddleware, token=settings.tokens.metrics_read)
+    app.add_middleware(IdempotencyMiddleware, config=settings.idempotency, clock=clock)
+    app.add_middleware(RateLimitMiddleware, config=settings.rate_limit, clock=clock)
+
+    @app.post("/dr/run")
+    async def run_dr(request: Request) -> JSONResponse:
+        correlation_id = _resolve_correlation_id(request, clock)
+        idem_key = request.headers.get("Idempotency-Key", correlation_id)
+        report = drill.run(
+            settings.artifacts_root,
+            settings.backups_root / "restore",
+            correlation_id=correlation_id,
+            namespace=settings.redis.namespace,
+            idempotency_key=idem_key,
+        )
+        logger.bind(correlation_id).info("dr.api.run", report=report)
+        return JSONResponse(report)
+
+    @app.post("/retention/enforce")
+    async def enforce_retention(request: Request) -> JSONResponse:
+        correlation_id = _resolve_correlation_id(request, clock)
+        result = retention.run(enforce=True)
+        logger.bind(correlation_id).info("retention.api.run", result=result)
+        return JSONResponse({"correlation_id": correlation_id, **result})
+
+    @app.post("/cleanup/run")
+    async def run_cleanup(request: Request) -> JSONResponse:
+        correlation_id = _resolve_correlation_id(request, clock)
+        result = cleanup.run()
+        payload = {
+            "correlation_id": correlation_id,
+            "removed_part_files": result.removed_part_files,
+            "removed_links": result.removed_links,
+        }
+        logger.bind(correlation_id).info("cleanup.api.run", payload=payload)
+        return JSONResponse(payload)
+
+    @app.get("/metrics")
+    async def metrics_endpoint(request: Request) -> Response:
+        token = request.headers.get("Authorization")
+        if token != f"Bearer {settings.tokens.metrics_read}":
+            raise HTTPException(status_code=401, detail="توکن نامعتبر است.")
+        data = generate_latest(metrics.registry)
+        return PlainTextResponse(data.decode("utf-8"))
+
+    @app.get("/healthz")
+    async def healthz() -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    @app.get("/readyz")
+    async def readyz() -> PlainTextResponse:
+        return PlainTextResponse("ready")
+
+    return app
+
+
+def get_debug_context(clock: Clock | None = None) -> dict[str, Any]:
+    import os
+
+    return {
+        "redis_keys": [],
+        "rate_limit_state": {},
+        "middleware_order": [],
+        "env": os.getenv("GITHUB_ACTIONS", "local"),
+        "timestamp": clock.now().isoformat() if clock else None,
+    }
+
+
+__all__ = ["create_reliability_app", "RateLimitMiddleware", "IdempotencyMiddleware", "AuthMiddleware", "get_debug_context"]

--- a/src/reliability/logging_utils.py
+++ b/src/reliability/logging_utils.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Mapping
+
+
+correlation_id_var: ContextVar[str] = ContextVar("reliability_correlation_id", default="-")
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(_DeterministicFormatter())
+    root = logging.getLogger("reliability")
+    root.setLevel(level)
+    root.handlers = [handler]
+
+
+class _DeterministicFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting only
+        payload = {
+            "ts": getattr(record, "ts", None),
+            "level": record.levelname,
+            "event": record.getMessage(),
+            "correlation_id": correlation_id_var.get(),
+        }
+        extra = getattr(record, "extra", None)
+        if isinstance(extra, Mapping):
+            payload.update(extra)
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+@dataclass(slots=True)
+class JSONLogger:
+    name: str
+
+    def bind(self, correlation_id: str) -> "JSONLoggerAdapter":
+        return JSONLoggerAdapter(logging.getLogger(self.name), correlation_id)
+
+
+class JSONLoggerAdapter:
+    def __init__(self, logger: logging.Logger, correlation_id: str) -> None:
+        self.logger = logger
+        self.correlation_id = correlation_id or "-"
+
+    def _log(self, level: int, event: str, **fields: Any) -> None:
+        token = correlation_id_var.set(self.correlation_id)
+        try:
+            safe_fields = {key: mask_value(value) for key, value in fields.items()}
+            payload = {
+                "extra": safe_fields,
+                "ts": fields.get("ts"),
+            }
+            self.logger.log(level, event, extra=payload)
+        finally:
+            correlation_id_var.reset(token)
+
+    def info(self, event: str, **fields: Any) -> None:
+        self._log(logging.INFO, event, **fields)
+
+    def warning(self, event: str, **fields: Any) -> None:
+        self._log(logging.WARNING, event, **fields)
+
+    def error(self, event: str, **fields: Any) -> None:
+        self._log(logging.ERROR, event, **fields)
+
+
+def mask_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if not value:
+            return value
+        if len(value) <= 6:
+            return value[0] + "***"
+        digest = sha256(value.encode("utf-8")).hexdigest()
+        return f"hash:{digest[:8]}"
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, Mapping):
+        return {key: mask_value(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [mask_value(item) for item in value]
+    return str(value)
+
+
+def persian_error(message: str, code: str, *, correlation_id: str, details: Any | None = None) -> Mapping[str, Any]:
+    payload = {
+        "خطا": message,
+        "کد": code,
+        "correlation_id": correlation_id,
+    }
+    if details is not None:
+        payload["جزئیات"] = details
+    return payload
+
+
+__all__ = ["JSONLogger", "configure_logging", "persian_error"]

--- a/src/reliability/metrics.py
+++ b/src/reliability/metrics.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+
+class ReliabilityMetrics:
+    """Prometheus metrics registry for reliability tooling."""
+
+    def __init__(self, registry: CollectorRegistry | None = None) -> None:
+        self.registry = registry or CollectorRegistry()
+        self.chaos_incidents = Counter(
+            "chaos_incidents_total",
+            "Number of chaos incidents injected by type.",
+            labelnames=("type", "scenario", "outcome", "reason", "namespace"),
+            registry=self.registry,
+        )
+        self.retention_actions = Counter(
+            "retention_actions_total",
+            "Retention operations performed grouped by mode.",
+            labelnames=("mode", "reason", "namespace"),
+            registry=self.registry,
+        )
+        self.cleanup_actions = Counter(
+            "cleanup_actions_total",
+            "Cleanup operations executed by kind.",
+            labelnames=("kind", "namespace"),
+            registry=self.registry,
+        )
+        self.dr_runs = Counter(
+            "dr_runs_total",
+            "Disaster recovery drill runs aggregated by status.",
+            labelnames=("status", "namespace"),
+            registry=self.registry,
+        )
+        self.dr_bytes = Counter(
+            "dr_bytes_total",
+            "Total bytes processed during DR drills.",
+            labelnames=("direction", "namespace"),
+            registry=self.registry,
+        )
+        self.durations = Histogram(
+            "reliability_duration_seconds",
+            "Duration histogram for reliability operations.",
+            labelnames=("component",),
+            registry=self.registry,
+            buckets=(0.01, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0),
+        )
+        self.inflight_backups = Gauge(
+            "dr_inflight_backups",
+            "Current number of backups running.",
+            registry=self.registry,
+        )
+        self.retries = Counter(
+            "reliability_retry_total",
+            "Total retries performed grouped by operation.",
+            labelnames=("operation", "namespace"),
+            registry=self.registry,
+        )
+        self.exhaustions = Counter(
+            "reliability_exhaustion_total",
+            "Total times an operation exhausted its retries.",
+            labelnames=("operation", "namespace"),
+            registry=self.registry,
+        )
+        self.operations = Counter(
+            "reliability_operations_total",
+            "Reliability operation outcomes.",
+            labelnames=("operation", "outcome", "reason", "namespace"),
+            registry=self.registry,
+        )
+
+    def observe_duration(self, component: str, seconds: float) -> None:
+        self.durations.labels(component=component).observe(max(0.0, seconds))
+
+    def mark_chaos(
+        self,
+        *,
+        scenario: str,
+        incident_type: str,
+        outcome: str,
+        reason: str,
+        namespace: str,
+    ) -> None:
+        self.chaos_incidents.labels(
+            type=incident_type,
+            scenario=scenario,
+            outcome=outcome,
+            reason=reason,
+            namespace=namespace,
+        ).inc()
+
+    def mark_retention(self, *, mode: str, reason: str, namespace: str) -> None:
+        self.retention_actions.labels(mode=mode, reason=reason, namespace=namespace).inc()
+
+    def mark_cleanup(self, *, kind: str, namespace: str) -> None:
+        self.cleanup_actions.labels(kind=kind, namespace=namespace).inc()
+
+    def mark_dr(self, *, status: str, namespace: str) -> None:
+        self.dr_runs.labels(status=status, namespace=namespace).inc()
+
+    def add_dr_bytes(self, *, direction: str, amount: int, namespace: str) -> None:
+        self.dr_bytes.labels(direction=direction, namespace=namespace).inc(max(0, amount))
+
+    def mark_retry(self, *, operation: str, namespace: str) -> None:
+        self.retries.labels(operation=operation, namespace=namespace).inc()
+
+    def mark_exhausted(self, *, operation: str, namespace: str) -> None:
+        self.exhaustions.labels(operation=operation, namespace=namespace).inc()
+
+    def mark_operation(self, *, operation: str, outcome: str, reason: str, namespace: str) -> None:
+        self.operations.labels(
+            operation=operation,
+            outcome=outcome,
+            reason=reason,
+            namespace=namespace,
+        ).inc()
+
+
+__all__ = ["ReliabilityMetrics"]

--- a/src/reliability/retention.py
+++ b/src/reliability/retention.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from .atomic import atomic_write_json
+from .clock import Clock
+from .config import RetentionConfig
+from .logging_utils import JSONLogger, persian_error
+from .metrics import ReliabilityMetrics
+
+
+@dataclass(slots=True)
+class RetentionFinding:
+    path: Path
+    reason: str
+    age_days: int
+    size_bytes: int
+
+
+class RetentionEnforcer:
+    def __init__(
+        self,
+        *,
+        artifacts_root: Path,
+        backups_root: Path,
+        config: RetentionConfig,
+        metrics: ReliabilityMetrics,
+        clock: Clock,
+        logger: JSONLogger,
+        report_path: Path,
+        csv_report_path: Path | None = None,
+        namespace: str = "default",
+    ) -> None:
+        self.artifacts_root = Path(artifacts_root)
+        self.backups_root = Path(backups_root)
+        self.config = config
+        self.metrics = metrics
+        self.clock = clock
+        self.logger = logger
+        self.report_path = Path(report_path)
+        self.csv_report_path = (
+            Path(csv_report_path) if csv_report_path is not None else self.report_path.with_suffix(".csv")
+        )
+        self.namespace = namespace or "default"
+
+    def run(self, *, enforce: bool = True) -> dict[str, object]:
+        findings = self._evaluate()
+        dry_payload = [self._finding_to_dict(finding) for finding in findings]
+        enforced: List[dict[str, object]] = []
+        if enforce:
+            enforced = [
+                self._finding_to_dict(finding)
+                for finding in self._enforce(findings)
+            ]
+        report = {
+            "dry_run": dry_payload,
+            "enforced": enforced,
+        }
+        self._write_reports(report)
+        outcome = "success"
+        reason = "completed"
+        if not findings:
+            reason = "no_action"
+        self.metrics.mark_operation(
+            operation="retention",
+            outcome=outcome,
+            reason=reason,
+            namespace=self.namespace,
+        )
+        return report
+
+    def _evaluate(self) -> List[RetentionFinding]:
+        now = self.clock.now().timestamp()
+        files = [
+            {
+                "path": path,
+                "mtime": mtime,
+                "size": size,
+                "age_days": math.floor(max(0.0, (now - mtime) / 86400)),
+            }
+            for path, mtime, size in self._iter_files()
+        ]
+        files.sort(key=lambda item: item["mtime"])
+        total_bytes = sum(item["size"] for item in files)
+        findings: List[RetentionFinding] = []
+
+        remaining: List[dict[str, object]] = []
+        for item in files:
+            if item["age_days"] > self.config.age_days:
+                finding = RetentionFinding(
+                    path=item["path"],
+                    reason="age",
+                    age_days=int(item["age_days"]),
+                    size_bytes=int(item["size"]),
+                )
+                findings.append(finding)
+                self.metrics.mark_retention(
+                    mode="dry_run",
+                    reason="age",
+                    namespace=self.namespace,
+                )
+                total_bytes -= int(item["size"])
+            else:
+                remaining.append(item)
+
+        if total_bytes > self.config.max_total_bytes:
+            remaining.sort(key=lambda item: item["size"], reverse=True)
+            for item in remaining:
+                if total_bytes <= self.config.max_total_bytes:
+                    break
+                finding = RetentionFinding(
+                    path=item["path"],
+                    reason="size",
+                    age_days=int(item["age_days"]),
+                    size_bytes=int(item["size"]),
+                )
+                findings.append(finding)
+                self.metrics.mark_retention(
+                    mode="dry_run",
+                    reason="size",
+                    namespace=self.namespace,
+                )
+                total_bytes -= int(item["size"])
+        return findings
+
+    def _enforce(self, findings: Iterable[RetentionFinding]) -> List[RetentionFinding]:
+        removed: List[RetentionFinding] = []
+        for finding in findings:
+            try:
+                finding.path.unlink(missing_ok=True)
+                removed.append(finding)
+                self.metrics.mark_retention(
+                    mode="enforce",
+                    reason=finding.reason,
+                    namespace=self.namespace,
+                )
+                self.logger.bind(f"retention-{finding.path.name}").info(
+                    "retention.deleted",
+                    path=str(finding.path),
+                    reason=finding.reason,
+                )
+            except OSError as exc:
+                self.metrics.mark_operation(
+                    operation="retention",
+                    outcome="failure",
+                    reason="delete_failed",
+                    namespace=self.namespace,
+                )
+                raise RuntimeError(
+                    persian_error(
+                        "حذف فایل در سیاست نگه‌داری شکست خورد.",
+                        "RETENTION_DELETE_FAILED",
+                        correlation_id=finding.path.name,
+                        details=str(exc),
+                    )
+                )
+        return removed
+
+    def _iter_files(self) -> Iterable[tuple[Path, float, int]]:
+        for root in (self.artifacts_root, self.backups_root):
+            if not root.exists():
+                continue
+            for path in root.rglob("*"):
+                if not path.is_file():
+                    continue
+                stat = path.stat()
+                yield path, stat.st_mtime, stat.st_size
+
+    def _finding_to_dict(self, finding: RetentionFinding) -> dict[str, object]:
+        path_text = str(finding.path)
+        if path_text.startswith(("=", "+", "-", "@")):
+            path_text = "'" + path_text
+        return {
+            "path": path_text,
+            "reason": finding.reason,
+            "age_days": int(finding.age_days),
+            "size_bytes": finding.size_bytes,
+        }
+
+    def _write_reports(self, report: dict[str, object]) -> None:
+        atomic_write_json(self.report_path, report)
+        rows: List[List[str]] = [["mode", "path", "reason", "age_days", "size_bytes"]]
+        for mode in ("dry_run", "enforced"):
+            for entry in report.get(mode, []):
+                rows.append(
+                    [
+                        mode,
+                        str(entry["path"]),
+                        str(entry["reason"]),
+                        str(entry["age_days"]),
+                        str(entry["size_bytes"]),
+                    ]
+                )
+        self._write_csv(rows)
+
+    def _write_csv(self, rows: List[List[str]]) -> None:
+        import csv
+
+        self.csv_report_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.csv_report_path.open("w", encoding="utf-8-sig", newline="") as handle:
+            writer = csv.writer(handle, quoting=csv.QUOTE_ALL, lineterminator="\r\n")
+            writer.writerows(rows)
+
+
+__all__ = ["RetentionEnforcer", "RetentionFinding"]

--- a/tests/chaos/test_db_conn_reset.py
+++ b/tests/chaos/test_db_conn_reset.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.reliability import Clock, DbConnectionResetInjector, ReliabilityMetrics
+from src.reliability.logging_utils import JSONLogger
+
+
+class FakeNow:
+    def __init__(self) -> None:
+        self.base = datetime(2024, 2, 1, tzinfo=ZoneInfo("UTC"))
+        self.calls = -1
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        return self.base + timedelta(milliseconds=100 * self.calls)
+
+
+@pytest.fixture()
+def clock() -> Clock:
+    return Clock(ZoneInfo("UTC"), FakeNow())
+
+
+@pytest.fixture()
+def metrics() -> ReliabilityMetrics:
+    return ReliabilityMetrics()
+
+
+def test_upload_survives_conn_reset_with_retry(tmp_path: Path, clock: Clock, metrics: ReliabilityMetrics) -> None:
+    logger = JSONLogger("test.pg")
+    scenario = DbConnectionResetInjector(
+        name="db_reset",
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        reports_root=tmp_path,
+    )
+    def upload() -> str:
+        return "uploaded"
+
+    report = scenario.run(
+        upload,
+        fault_plan=[1, 1, 0],
+        correlation_id="pg-rid",
+        namespace="pg-chaos",
+    )
+    assert report["success"] is True
+    assert report["attempts"] == 3
+
+    success_metric = metrics.chaos_incidents.labels(
+        type="postgres",
+        scenario="db_reset",
+        outcome="success",
+        reason="completed",
+        namespace="pg-chaos",
+    )
+    assert success_metric._value.get() == 1.0
+
+    retry_metric = metrics.retries.labels(operation="chaos:db_reset", namespace="pg-chaos")
+    assert retry_metric._value.get() == 2.0
+
+    json_payload = (tmp_path / "db_reset.json").read_text(encoding="utf-8")
+    assert "pg-chaos" in json_payload

--- a/tests/chaos/test_redis_flap.py
+++ b/tests/chaos/test_redis_flap.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.reliability import Clock, RedisFlapInjector, ReliabilityMetrics
+from src.reliability.logging_utils import JSONLogger
+
+
+class FakeNow:
+    def __init__(self) -> None:
+        self.base = datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC"))
+        self.calls = -1
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        return self.base + timedelta(seconds=self.calls)
+
+
+@pytest.fixture()
+def clock() -> Clock:
+    return Clock(ZoneInfo("UTC"), FakeNow())
+
+
+@pytest.fixture()
+def metrics() -> ReliabilityMetrics:
+    return ReliabilityMetrics()
+
+
+def test_export_under_redis_flap_no_slo_violation(tmp_path: Path, clock: Clock, metrics: ReliabilityMetrics) -> None:
+    logger = JSONLogger("test.reliability")
+    scenario = RedisFlapInjector(
+        name="redis_export",
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        reports_root=tmp_path,
+    )
+    def operation() -> dict[str, bool]:
+        return {"ok": True}
+
+    report = scenario.run(
+        operation,
+        fault_plan=[1, 0],
+        correlation_id="rid-test",
+        namespace="chaos-tests",
+    )
+    assert report["success"] is True
+    assert report["attempts"] == 2
+    assert report["duration_s"] >= 0.0
+    chaos_success = metrics.chaos_incidents.labels(
+        type="redis",
+        scenario="redis_export",
+        outcome="success",
+        reason="completed",
+        namespace="chaos-tests",
+    )
+    assert chaos_success._value.get() == 1.0
+
+    retries = metrics.retries.labels(operation="chaos:redis_export", namespace="chaos-tests")
+    assert retries._value.get() == 1.0
+
+    report_file = tmp_path / "redis_export.json"
+    payload = json.loads(report_file.read_text(encoding="utf-8"))
+    assert payload["namespace"] == "chaos-tests"
+    assert payload["injected"] == 1

--- a/tests/dr/test_backup_restore.py
+++ b/tests/dr/test_backup_restore.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from src.reliability import Clock, DisasterRecoveryDrill, ReliabilityMetrics
+from src.reliability.logging_utils import JSONLogger
+
+
+class FakeNow:
+    def __init__(self) -> None:
+        self.base = datetime(2024, 3, 1, tzinfo=ZoneInfo("UTC"))
+        self.offsets = [0, 5, 10, 15]
+        self.index = -1
+
+    def __call__(self) -> datetime:
+        self.index += 1
+        offset = self.offsets[min(self.index, len(self.offsets) - 1)]
+        return self.base + timedelta(seconds=offset)
+
+
+def test_restore_verifies_sha256_and_records_rto_rpo(tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    restore = tmp_path / "restore"
+    backups = tmp_path / "backups"
+    report_path = tmp_path / "dr_report.json"
+    source.mkdir()
+    backups.mkdir()
+    content = "سلام".encode("utf-8")
+    (source / "data.txt").write_bytes(content)
+    expected_sha = hashlib.sha256(content).hexdigest()
+
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("test.dr")
+    clock = Clock(ZoneInfo("UTC"), FakeNow())
+    drill = DisasterRecoveryDrill(
+        backups_root=backups,
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        report_path=report_path,
+    )
+
+    report = drill.run(source, restore, correlation_id="cor-1", namespace="drill-tests")
+
+    restored_file = restore / "data.txt"
+    assert restored_file.read_bytes() == content
+
+    stored = json.loads(report_path.read_text(encoding="utf-8"))
+    assert stored["rto_s"] == report["rto_s"]
+    assert stored["rpo_s"] == report["rpo_s"]
+    assert stored["rto_ms"] == report["rto_ms"]
+    assert stored["rpo_ms"] == report["rpo_ms"]
+    assert stored["sha256"][0]["sha256"] == expected_sha
+
+    assert report["rto_ms"] >= 0
+    assert report["rpo_ms"] >= 0
+
+    success_counter = metrics.dr_runs.labels(status="success", namespace="drill-tests")
+    assert success_counter._value.get() == 1.0
+
+    operation_counter = metrics.operations.labels(
+        operation="drill", outcome="success", reason="completed", namespace="drill-tests"
+    )
+    assert operation_counter._value.get() == 1.0
+
+    backup_metric = metrics.dr_bytes.labels(direction="backup", namespace="drill-tests")
+    restore_metric = metrics.dr_bytes.labels(direction="restore", namespace="drill-tests")
+    assert backup_metric._value.get() == len(content)
+    assert restore_metric._value.get() == len(content)

--- a/tests/mw/test_middleware_order.py
+++ b/tests/mw/test_middleware_order.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import asyncio
+
+import httpx
+from zoneinfo import ZoneInfo
+
+from src.reliability import (
+    CleanupDaemon,
+    Clock,
+    DisasterRecoveryDrill,
+    ReliabilityMetrics,
+    ReliabilitySettings,
+    RetentionEnforcer,
+    create_reliability_app,
+)
+from src.reliability.logging_utils import JSONLogger
+
+
+def test_order_and_token_guard(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    backups = tmp_path / "backups"
+    artifacts.mkdir()
+    backups.mkdir()
+
+    settings = ReliabilitySettings.model_validate(
+        {
+            "redis": {"dsn": "redis://localhost:6379/0", "namespace": "mw"},
+            "postgres": {
+                "read_write_dsn": "postgresql://user:pass@localhost/db",
+                "replica_dsn": "postgresql://user:pass@localhost/db",
+            },
+            "artifacts_root": str(artifacts),
+            "backups_root": str(backups),
+            "retention": {"age_days": 1, "max_total_bytes": 1024},
+            "cleanup": {"part_max_age": 60, "link_ttl": 60},
+            "tokens": {"metrics_read": "metrics-token"},
+            "timezone": "UTC",
+            "rate_limit": {"default_rule": {"requests": 5, "window_seconds": 60}, "fail_open": False},
+            "idempotency": {"ttl_seconds": 3600, "storage_prefix": "idem"},
+        }
+    )
+
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("test.mw")
+    clock = Clock(ZoneInfo("UTC"))
+    retention = RetentionEnforcer(
+        artifacts_root=artifacts,
+        backups_root=backups,
+        config=settings.retention,
+        metrics=metrics,
+        clock=clock,
+        logger=logger,
+        report_path=tmp_path / "retention_report.json",
+        csv_report_path=tmp_path / "retention_report.csv",
+        namespace="mw-tests",
+    )
+    cleanup = CleanupDaemon(
+        artifacts_root=artifacts,
+        backups_root=backups,
+        config=settings.cleanup,
+        metrics=metrics,
+        clock=clock,
+        logger=logger,
+        registry_path=artifacts / "signed_urls.json",
+        namespace="mw-tests",
+        report_path=tmp_path / "cleanup_report.json",
+    )
+    drill = DisasterRecoveryDrill(
+        backups_root=backups,
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        report_path=tmp_path / "dr_report.json",
+    )
+
+    app = create_reliability_app(
+        settings=settings,
+        metrics=metrics,
+        retention=retention,
+        cleanup=cleanup,
+        drill=drill,
+        logger=logger,
+        clock=clock,
+    )
+
+    async def _request() -> httpx.Response:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            return await client.post(
+                "/retention/enforce",
+                headers={
+                    "Authorization": "Bearer metrics-token",
+                    "Idempotency-Key": "mw-1",
+                    "X-RateLimit-Key": "mw",
+                    "X-Request-ID": "rid-1",
+                },
+            )
+
+    response = asyncio.run(_request())
+    assert response.status_code == 200
+    assert response.headers["X-Middleware-Order"] == "RateLimit,Idempotency,Auth"
+
+    async def _metrics(token: str | None) -> int:
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            res = await client.get("/metrics", headers=headers)
+        return res.status_code
+
+    unauthorized = asyncio.run(_metrics(None))
+    assert unauthorized == 401
+
+    authorized = asyncio.run(_metrics("metrics-token"))
+    assert authorized == 200

--- a/tests/obs/test_metrics_labels.py
+++ b/tests/obs/test_metrics_labels.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from src.reliability import ReliabilityMetrics
+
+
+def _label_dicts(counter) -> list[dict[str, str]]:
+    collected = counter.collect()[0]
+    return [dict(sample.labels) for sample in collected.samples]
+
+
+def test_retention_cleanup_chaos_metrics_labels() -> None:
+    metrics = ReliabilityMetrics()
+    metrics.mark_chaos(
+        scenario="redis_export",
+        incident_type="redis",
+        outcome="fault",
+        reason="injected_fault",
+        namespace="obs",
+    )
+    metrics.mark_retention(mode="dry_run", reason="age", namespace="obs")
+    metrics.mark_cleanup(kind="part_file", namespace="obs")
+
+    chaos_labels = _label_dicts(metrics.chaos_incidents)
+    assert any(
+        label.get("outcome") == "fault"
+        and label.get("type") == "redis"
+        and label.get("reason") == "injected_fault"
+        and label.get("namespace") == "obs"
+        for label in chaos_labels
+    )
+
+    retention_labels = _label_dicts(metrics.retention_actions)
+    assert any(
+        label.get("mode") == "dry_run"
+        and label.get("reason") == "age"
+        and label.get("namespace") == "obs"
+        for label in retention_labels
+    )
+
+    cleanup_labels = _label_dicts(metrics.cleanup_actions)
+    assert any(
+        label.get("kind") == "part_file" and label.get("namespace") == "obs"
+        for label in cleanup_labels
+    )

--- a/tests/ops/test_cleanupd.py
+++ b/tests/ops/test_cleanupd.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from src.reliability import CleanupDaemon, Clock, ReliabilityMetrics
+from src.reliability.config import CleanupConfig
+from src.reliability.logging_utils import JSONLogger
+
+
+def test_removes_stale_part_and_expired_links(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    backups = tmp_path / "backups"
+    artifacts.mkdir()
+    backups.mkdir()
+    old_part = artifacts / "sample.part"
+    old_part.write_text("temp", encoding="utf-8")
+    fresh_part = backups / "fresh.part"
+    fresh_part.write_text("keep", encoding="utf-8")
+
+    now = datetime(2024, 5, 1, tzinfo=ZoneInfo("UTC"))
+    cutoff = now - timedelta(seconds=120)
+    os.utime(old_part, (cutoff.timestamp(), cutoff.timestamp()))
+
+    registry = artifacts / "signed_urls.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "expired": {"created_at": (now - timedelta(seconds=3600)).timestamp()},
+                "active": {"created_at": (now - timedelta(seconds=10)).timestamp()},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report_path = tmp_path / "cleanup_report.json"
+    metrics = ReliabilityMetrics()
+    daemon = CleanupDaemon(
+        artifacts_root=artifacts,
+        backups_root=backups,
+        config=CleanupConfig(part_max_age=60, link_ttl=60),
+        metrics=metrics,
+        clock=Clock(ZoneInfo("UTC"), lambda: now),
+        logger=JSONLogger("test.cleanup"),
+        registry_path=registry,
+        namespace="cleanup-tests",
+        report_path=report_path,
+    )
+
+    result = daemon.run()
+
+    assert str(old_part) in result.removed_part_files
+    assert fresh_part.exists()
+
+    report_payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report_payload["namespace"] == "cleanup-tests"
+    assert str(old_part) in report_payload["removed_part_files"]
+
+    registry_payload = json.loads(registry.read_text(encoding="utf-8"))
+    assert "expired" not in registry_payload
+    assert "active" in registry_payload
+
+    part_metric = metrics.cleanup_actions.labels(kind="part_file", namespace="cleanup-tests")
+    link_metric = metrics.cleanup_actions.labels(kind="signed_url", namespace="cleanup-tests")
+    assert part_metric._value.get() == 1.0
+    assert link_metric._value.get() == 1.0
+
+    op_metric = metrics.operations.labels(
+        operation="cleanup", outcome="success", reason="completed", namespace="cleanup-tests"
+    )
+    assert op_metric._value.get() == 1.0

--- a/tests/ops/test_retention_enforcer.py
+++ b/tests/ops/test_retention_enforcer.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from src.reliability import Clock, ReliabilityMetrics, RetentionEnforcer
+from src.reliability.config import RetentionConfig
+from src.reliability.logging_utils import JSONLogger
+
+
+class FakeNow:
+    def __init__(self) -> None:
+        self.value = datetime(2024, 4, 1, tzinfo=ZoneInfo("UTC"))
+
+    def __call__(self) -> datetime:
+        return self.value
+
+
+def test_dry_run_then_enforce_removes_out_of_policy(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    backups = tmp_path / "backups"
+    report_path = tmp_path / "retention_report.json"
+    csv_path = tmp_path / "retention_report.csv"
+    artifacts.mkdir()
+    backups.mkdir()
+    old_file = artifacts / "old.bin"
+    old_file.write_bytes(b"x" * 10)
+    young_file = artifacts / "young.bin"
+    young_file.write_bytes(b"y" * 5)
+    big_backup = backups / "big.bin"
+    big_backup.write_bytes(b"z" * 20)
+
+    fake_now = FakeNow()
+    three_days_ago = fake_now.value - timedelta(days=3)
+    os.utime(old_file, (three_days_ago.timestamp(), three_days_ago.timestamp()))
+
+    metrics = ReliabilityMetrics()
+    enforcer = RetentionEnforcer(
+        artifacts_root=artifacts,
+        backups_root=backups,
+        config=RetentionConfig(age_days=1, max_total_bytes=20),
+        metrics=metrics,
+        clock=Clock(ZoneInfo("UTC"), fake_now),
+        logger=JSONLogger("test.retention"),
+        report_path=report_path,
+        csv_report_path=csv_path,
+        namespace="retention-tests",
+    )
+
+    result = enforcer.run(enforce=True)
+
+    dry = {entry["path"]: entry for entry in result["dry_run"]}
+    assert str(old_file) in dry
+    assert dry[str(old_file)]["reason"] == "age"
+
+    enforced_paths = {entry["path"] for entry in result["enforced"]}
+    assert str(old_file) in enforced_paths
+    assert str(big_backup) in enforced_paths
+    assert young_file.exists()
+
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    assert len(data["enforced"]) == len(result["enforced"])
+
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        rows = list(csv.reader(handle))
+    assert rows[0] == ["mode", "path", "reason", "age_days", "size_bytes"]
+    assert len(rows) == 1 + len(result["dry_run"]) + len(result["enforced"])
+    dry_row = next(row for row in rows if row[0] == "dry_run" and row[2] == "age")
+    assert dry_row[3].isdigit()
+
+    dry_age_metric = metrics.retention_actions.labels(
+        mode="dry_run", reason="age", namespace="retention-tests"
+    )
+    dry_size_metric = metrics.retention_actions.labels(
+        mode="dry_run", reason="size", namespace="retention-tests"
+    )
+    enforce_age_metric = metrics.retention_actions.labels(
+        mode="enforce", reason="age", namespace="retention-tests"
+    )
+    enforce_size_metric = metrics.retention_actions.labels(
+        mode="enforce", reason="size", namespace="retention-tests"
+    )
+    assert dry_age_metric._value.get() == 1.0
+    assert dry_size_metric._value.get() == 1.0
+    assert enforce_age_metric._value.get() == 1.0
+    assert enforce_size_metric._value.get() == 1.0
+
+    op_metric = metrics.operations.labels(
+        operation="retention",
+        outcome="success",
+        reason="completed",
+        namespace="retention-tests",
+    )
+    assert op_metric._value.get() == 1.0

--- a/tests/ops/test_settings_guard.py
+++ b/tests/ops/test_settings_guard.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.reliability.config import ReliabilitySettings
+
+
+@pytest.fixture()
+def base_payload(tmp_path):
+    return {
+        "redis": {"dsn": "redis://localhost:6379/0", "namespace": "guard"},
+        "postgres": {
+            "read_write_dsn": "postgresql://user:pass@localhost/db",
+            "replica_dsn": "postgresql://user:pass@localhost/db",
+        },
+        "artifacts_root": str(tmp_path / "artifacts"),
+        "backups_root": str(tmp_path / "backups"),
+        "retention": {"age_days": 1, "max_total_bytes": 1024},
+        "cleanup": {"part_max_age": 60, "link_ttl": 60},
+        "tokens": {"metrics_read": "metrics-token"},
+        "timezone": "Asia/Tehran",
+        "rate_limit": {"default_rule": {"requests": 5, "window_seconds": 60}},
+    }
+
+
+def test_reject_unknown_keys_and_validate_tz(base_payload):
+    payload = dict(base_payload)
+    payload["unknown"] = "value"
+    with pytest.raises(ValidationError):
+        ReliabilitySettings.model_validate(payload)
+
+    bad_tz = dict(base_payload, timezone="Not/Real")
+    with pytest.raises(ValidationError):
+        ReliabilitySettings.model_validate(bad_tz)
+
+    settings = ReliabilitySettings.model_validate(base_payload)
+    assert settings.redis.namespace == "guard"
+    assert settings.clock().key == "Asia/Tehran"

--- a/tools/chaos/db_conn_reset.py
+++ b/tools/chaos/db_conn_reset.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import typer
+
+from src.reliability import Clock, DbConnectionResetInjector, ReliabilityMetrics, ReliabilitySettings
+from src.reliability.logging_utils import JSONLogger, configure_logging
+
+app = typer.Typer(help="PostgreSQL connection reset injector.")
+
+
+def _load_settings(config_path: Path) -> ReliabilitySettings:
+    content = config_path.read_text(encoding="utf-8")
+    return ReliabilitySettings.model_validate_json(content)
+
+
+@app.command()
+def reset(
+    config: Path = typer.Argument(..., help="Path to reliability settings JSON."),
+    plan: str = typer.Option("1,0", help="Comma separated fault plan."),
+    report_dir: Path = typer.Option(Path("reports/chaos"), help="Directory for chaos reports."),
+    correlation_id: str | None = typer.Option(None, help="Correlation identifier."),
+) -> None:
+    settings = _load_settings(config)
+    configure_logging()
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("reliability.chaos")
+    clock = Clock(settings.clock())
+    scenario = DbConnectionResetInjector(
+        name="db_conn_reset",
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        reports_root=report_dir,
+    )
+    plan_values: List[int] = [int(value.strip() or "0") for value in plan.split(",") if value.strip() or value == "0"]
+    scenario.run(lambda: True, fault_plan=plan_values, correlation_id=correlation_id, namespace="postgres")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tools/chaos/redis_flap.py
+++ b/tools/chaos/redis_flap.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import typer
+
+from src.reliability import Clock, RedisFlapInjector, ReliabilityMetrics, ReliabilitySettings
+from src.reliability.logging_utils import JSONLogger, configure_logging
+
+app = typer.Typer(help="Redis chaos-lite fault injector.")
+
+
+def _load_settings(config_path: Path) -> ReliabilitySettings:
+    content = config_path.read_text(encoding="utf-8")
+    return ReliabilitySettings.model_validate_json(content)
+
+
+@app.command()
+def flap(
+    config: Path = typer.Argument(..., help="Path to reliability settings JSON."),
+    plan: str = typer.Option("1,0", help="Comma separated fault plan (1=inject,0=success)."),
+    report_dir: Path = typer.Option(Path("reports/chaos"), help="Directory for chaos reports."),
+    correlation_id: str | None = typer.Option(None, help="Correlation identifier."),
+) -> None:
+    settings = _load_settings(config)
+    configure_logging()
+    metrics = ReliabilityMetrics()
+    logger = JSONLogger("reliability.chaos")
+    clock = Clock(settings.clock())
+    scenario = RedisFlapInjector(
+        name="redis_flap",
+        metrics=metrics,
+        logger=logger,
+        clock=clock,
+        reports_root=report_dir,
+    )
+    plan_values: List[int] = [int(value.strip() or "0") for value in plan.split(",") if value.strip() or value == "0"]
+    scenario.run(lambda: True, fault_plan=plan_values, correlation_id=correlation_id, namespace=settings.redis.namespace)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()


### PR DESCRIPTION
## Summary
- normalize reliability settings input, default the timezone to Asia/Baku, and expose a reusable clock builder consumed by the reliability CLIs
- switch chaos retries to blake2-seeded deterministic jitter and harden retention reporting by flooring age calculations and guarding Excel-sensitive values
- derive DR drill run IDs from idempotency keys, pipe them through the FastAPI control plane, and add health/ready endpoints alongside timestamp-stable debug context
- enrich chaos metrics with explicit reason labels, and extend DR byte counters with namespace scoping for observability parity
- produce atomic cleanup and retention evidence artifacts (JSON + Excel-safe CSV) while wiring the Typer entrypoints to the reports/ hierarchy

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chaos/test_redis_flap.py tests/chaos/test_db_conn_reset.py tests/dr/test_backup_restore.py tests/ops/test_retention_enforcer.py tests/ops/test_cleanupd.py tests/obs/test_metrics_labels.py tests/mw/test_middleware_order.py tests/ops/test_settings_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68d9925dfd908321a9f350ea6baf75dc