### PR TITLE
Wire debug context enrichment into logging

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,46 @@
+# عملیات سامانه تخصیص دانشجو-مربی
+
+## sso-onboarding
+
+### نمای کلی
+- این مرحله، اتصال SSO سازمانی (OIDC/SAML) را فعال می‌کند و نشست‌های گذرگاهی را در Redis مدیریت می‌نماید.
+- تمامی زمان‌ها با ساعت تزریق‌شده (Asia/Tehran) محاسبه می‌شوند؛ هیچ استفاده‌ای از `datetime.now()` مجاز نیست.
+
+### پیش‌نیازهای Go/No-Go
+- [ ] متغیرهای محیطی مطابق `src/config/env_schema.py::SSOConfig` مقداردهی شده‌اند؛ هیچ کلید ناشناخته‌ای وجود ندارد.
+- [ ] آداپتور انتخابی (OIDC یا SAML) در حالت سبز (`SSO_BLUE_GREEN_STATE=green`) گرم و آماده است.
+- [ ] تست‌های واحد و یکپارچه `pytest -q tests/auth tests/mw tests/obs tests/blue_green` بدون خطا اجرا شده‌اند.
+- [ ] دسترسی `/metrics` همچنان با توکن موجود محافظت می‌شود و شمارنده‌های `auth_ok_total` و `auth_fail_total{reason}` افزایش می‌یابند.
+- [ ] لاگ‌ها و رخدادهای ممیزی فاقد PII هستند (شناسه‌ها هش یا ماسک شده‌اند).
+
+### فرآیند فعال‌سازی آبی/سبز
+1. مقداردهی `SSO_BLUE_GREEN_STATE=warming` و بارگذاری نرم‌افزار جدید.
+2. اجرای تست‌های دود `tests/mw/test_order_auth_callback.py` و `tests/blue_green/test_zero_downtime.py` روی محیط در حال گرم شدن.
+3. پس از موفقیت، تغییر مقدار به `green` و نظارت بر متریک‌های `auth_duration_seconds` (p95 < 200ms).
+4. در صورت بروز خطا، بازگشت به مقدار `blue`؛ نشست‌های فعال با TTL ۱۵ دقیقه در Redis باقی می‌مانند.
+
+### ماتریس نگاشت ویژگی‌ها
+| منبع | نقش | اسکوپ مرکز | توضیح |
+|------|-----|------------|-------|
+| OIDC.claims.role | ADMIN/MANAGER | `center_scope` یا `ALL` | با نرمال‌سازی ارقام فارسی/عربی |
+| SAML.Attribute `role` | ADMIN/MANAGER | `center_scope` | رد کردن مقادیر نامعتبر |
+| LDAP گروه | ADMIN/MANAGER | استخراج‌شده از قوانین `LDAP_GROUP_RULES` | قالب `گروه:نقش:اسکوپ` |
+
+### عیب‌یابی سریع
+- «کلید ناشناخته» → بررسی متغیرهای محیطی با `tests/config/test_env_schema.py`.
+- «توکن بازگشتی نامعتبر است» → بازبینی JWKS و مطابقت `kid` در `auth/oidc_adapter.py`.
+- «پیام هویتی بسیار بزرگ است» → تأیید اندازه Assertion (حداکثر ۲۵۰KB).
+- زمان‌های طولانی در Callback → بررسی تأخیر LDAP و شمارش تلاش‌های تکرار (`auth_retry_attempts_total`).
+
+## sso-oncall-metrics
+
+- هشدار «ورودهای مکرر ناموفق» زمانی فعال می‌شود که `auth_retry_exhaustion_total{adapter,reason}` در مدت ۵ دقیقه بیش از ۳ مقدار جدید ثبت کند؛ تفکیک بر اساس `adapter ∈ {"oidc","ldap"}` و `reason` (مانند `"jwks"` یا `"timeout"`).
+- برای پایش تأخیرها، هیستوگرام `auth_retry_backoff_seconds` را با تمرکز بر باکت‌های >0.2s بررسی کنید؛ افزایش ناگهانی نشان‌دهنده کندی سرویس IdP یا LDAP است.
+- هنگام بررسی رخداد، ابتدا `auth_retry_attempts_total` و `auth_retry_exhaustion_total` را از `/metrics` (با توکن موجود) نمونه‌برداری کنید و سپس `DebugContext` ثبت‌شده در لاگ‌های JSON را با فیلد `debug_context` استخراج کنید؛ این فیلد شامل `rid/operation/namespace/last_error` و خلاصه کلیدهای Redis مجاز است.
+- اگر مقدار هیستوگرام رشد می‌کند ولی شمارندهٔ `exhaustion` ثابت است، احتمالاً backoff جبران‌گر است؛ جدول «عیب‌یابی سریع» را دنبال کنید و با استفاده از `DebugContext` وضعیت کلیدهای `sso_session:*` را بررسی نمایید.
+- در زمان پاسخ‌گویی به هشدار، لاگ‌ها را با فیلتر `rid` بررسی کنید؛ در صورت وجود چند RID با خطا، از اسکریپت‌های موجود در `tests/debug/test_debug_context_default_factory_integration.py` برای بازتولید شرایط استفاده کنید.
+
+### بازیابی و بازگشت
+- برای rollback، مقدار `SSO_BLUE_GREEN_STATE` را به `blue` برگردانید؛ این کار POSTها را مسدود می‌کند اما نشست‌های موجود فعال می‌مانند تا TTL خاتمه یابد.
+- پاک‌سازی دستی نشست‌ها: اجرای `redis-cli --scan 'sso_session:*' | xargs redis-cli del` در صورت نیاز (با احتیاط).
+- تمامی رویدادهای ممیزی در جدول `audit_events` با `action ∈ {AUTHN_OK, AUTHN_FAIL}` موجود است؛ جهت بررسی رخدادهای اخیر از ابزار گزارش‌گیری استفاده کنید.

--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,13 @@
+"""SSO adapters and session utilities for the student-mentor allocation system."""
+
+from .models import BridgeSession
+from .oidc_adapter import OIDCAdapter
+from .saml_adapter import SAMLAdapter
+from .ldap_adapter import LdapGroupMapper
+
+__all__ = [
+    "BridgeSession",
+    "OIDCAdapter",
+    "SAMLAdapter",
+    "LdapGroupMapper",
+]

--- a/auth/errors.py
+++ b/auth/errors.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class AuthError(Exception):
+    code: str
+    message_fa: str
+    reason: str
+
+    def __str__(self) -> str:  # pragma: no cover - representational
+        return f"{self.code}: {self.message_fa}"  # type: ignore[str-format]
+
+
+class ConfigError(AuthError):
+    pass
+
+
+class ProviderError(AuthError):
+    pass
+
+
+__all__ = ["AuthError", "ConfigError", "ProviderError"]

--- a/auth/ldap_adapter.py
+++ b/auth/ldap_adapter.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable, Mapping
+
+from .errors import ProviderError
+from .metrics import AuthMetrics
+from .utils import exponential_backoff, fold_digits, masked, sanitize_scope
+
+LOGGER = logging.getLogger("sso.ldap")
+@dataclass(slots=True)
+class LdapSettings:
+    timeout_seconds: float = 3.0
+    group_rules: Mapping[str, tuple[str, str]] | None = None
+
+
+class LdapGroupMapper:
+    """Resolve role/center_scope pairs using LDAP group membership."""
+
+    def __init__(
+        self,
+        fetch_groups: Callable[[str], Awaitable[Iterable[str]]],
+        *,
+        settings: LdapSettings,
+        metrics: AuthMetrics | None = None,
+        max_retries: int = 3,
+        backoff_seconds: float = 0.1,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._fetch_groups = fetch_groups
+        self._settings = settings
+        self._metrics = metrics
+        self._max_retries = max(1, max_retries)
+        self._backoff_seconds = backoff_seconds
+        self._sleep = sleep or asyncio.sleep
+
+    async def __call__(
+        self,
+        claims: Mapping[str, Any],
+        *,
+        correlation_id: str | None = None,
+    ) -> tuple[str, str]:
+        user = str(claims.get("sub") or claims.get("NameID") or "")
+        groups = claims.get("groups")
+        if not groups:
+            groups = await self._safe_fetch(user, rid=correlation_id or masked(user))
+        if isinstance(groups, str):
+            group_list = [groups]
+        else:
+            group_list = list(groups)
+        role, scope = self._apply_rules(group_list)
+        LOGGER.info(
+            "LDAP_GROUP_MAPPED",
+            extra={
+                "user": masked(user),
+                "role": role,
+                "scope": scope,
+            },
+        )
+        return role, scope
+
+    async def _safe_fetch(self, user: str, *, rid: str) -> Iterable[str]:
+        if not user:
+            raise ProviderError(
+                code="AUTH_FORBIDDEN",
+                message_fa="دسترسی مجاز نیست؛ نقش یا اسکوپ کافی نیست.",
+                reason="missing_user",
+            )
+        reason = "timeout"
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                return await asyncio.wait_for(
+                    self._fetch_groups(user),
+                    timeout=self._settings.timeout_seconds,
+                )
+            except asyncio.TimeoutError as exc:
+                if attempt == self._max_retries:
+                    if self._metrics:
+                        self._metrics.retry_exhaustion_total.labels(adapter="ldap", reason=reason).inc()
+                    message = "پاسخ‌گویی سرویس دایرکتوری به‌موقع نبود؛ بعداً تلاش کنید."
+                    raise ProviderError(
+                        code="AUTH_LDAP_TIMEOUT",
+                        message_fa=message,
+                        reason="timeout",
+                    ) from exc
+                if self._metrics:
+                    self._metrics.retry_attempts_total.labels(adapter="ldap", reason=reason).inc()
+                delay = exponential_backoff(
+                    self._backoff_seconds,
+                    attempt,
+                    jitter_seed=f"{rid}:{reason}",
+                )
+                if self._metrics:
+                    self._metrics.retry_backoff_seconds.labels(adapter="ldap", reason=reason).observe(delay)
+                await self._sleep(delay)
+
+    def _apply_rules(self, groups: Iterable[str]) -> tuple[str, str]:
+        rules = self._settings.group_rules or {}
+        for group in groups:
+            group_key = fold_digits(str(group).strip()) or ""
+            if not group_key:
+                continue
+            if group_key in rules:
+                role, scope = rules[group_key]
+                if role not in {"ADMIN", "MANAGER"}:
+                    continue
+                scope = "ALL" if role == "ADMIN" else sanitize_scope(scope)
+                return role, scope
+            if ":" in group_key:
+                role_candidate, scope_candidate = group_key.split(":", 1)
+                role_candidate = role_candidate.upper()
+                if role_candidate in {"ADMIN", "MANAGER"}:
+                    try:
+                        scope = "ALL" if role_candidate == "ADMIN" else sanitize_scope(scope_candidate)
+                        return role_candidate, scope
+                    except ValueError:  # noqa: BLE001
+                        continue
+        raise ProviderError(
+            code="AUTH_FORBIDDEN",
+            message_fa="دسترسی مجاز نیست؛ نقش یا اسکوپ کافی نیست.",
+            reason="no_matching_group",
+        )
+
+
+__all__ = ["LdapGroupMapper", "LdapSettings"]

--- a/auth/metrics.py
+++ b/auth/metrics.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from prometheus_client import CollectorRegistry, Counter, Histogram
+
+
+@dataclass(slots=True)
+class AuthMetrics:
+    registry: CollectorRegistry
+    ok_total: Counter
+    fail_total: Counter
+    duration_seconds: Histogram
+    retry_attempts_total: Counter
+    retry_exhaustion_total: Counter
+    retry_backoff_seconds: Histogram
+
+    @classmethod
+    def build(cls, registry: CollectorRegistry | None = None) -> "AuthMetrics":
+        registry = registry or CollectorRegistry()
+        ok_total = Counter(
+            "auth_ok_total",
+            "Successful SSO authentications",
+            labelnames=("provider",),
+            registry=registry,
+        )
+        fail_total = Counter(
+            "auth_fail_total",
+            "Failed SSO authentications",
+            labelnames=("provider", "reason"),
+            registry=registry,
+        )
+        duration_seconds = Histogram(
+            "auth_duration_seconds",
+            "Authentication latency per provider",
+            labelnames=("provider",),
+            registry=registry,
+        )
+        retry_attempts_total = Counter(
+            "auth_retry_attempts_total",
+            "Retries performed against identity providers",
+            labelnames=("adapter", "reason"),
+            registry=registry,
+        )
+        retry_exhaustion_total = Counter(
+            "auth_retry_exhaustion_total",
+            "Authentication retries exhausted",
+            labelnames=("adapter", "reason"),
+            registry=registry,
+        )
+        retry_backoff_seconds = Histogram(
+            "auth_retry_backoff_seconds",
+            "Backoff duration applied between retry attempts",
+            labelnames=("adapter", "reason"),
+            registry=registry,
+        )
+        return cls(
+            registry=registry,
+            ok_total=ok_total,
+            fail_total=fail_total,
+            duration_seconds=duration_seconds,
+            retry_attempts_total=retry_attempts_total,
+            retry_exhaustion_total=retry_exhaustion_total,
+            retry_backoff_seconds=retry_backoff_seconds,
+        )
+
+
+__all__ = ["AuthMetrics"]

--- a/auth/models.py
+++ b/auth/models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+
+@dataclass(slots=True)
+class BridgeSession:
+    """Server-side representation of an authenticated SSO session."""
+
+    sid: str
+    role: Literal["ADMIN", "MANAGER"]
+    center_scope: str
+    issued_at: datetime
+    expires_at: datetime
+
+    @property
+    def ttl_seconds(self) -> int:
+        return max(0, int((self.expires_at - self.issued_at).total_seconds()))
+
+
+__all__ = ["BridgeSession"]

--- a/auth/oidc_adapter.py
+++ b/auth/oidc_adapter.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping
+
+import httpx
+
+from src.reliability.clock import Clock
+
+if TYPE_CHECKING:
+    from src.debug.debug_context import DebugContext
+
+from .errors import AuthError, ProviderError
+from .metrics import AuthMetrics
+from .models import BridgeSession
+from .session_store import SessionStore
+from .utils import (
+    encode_base64url,
+    exponential_backoff,
+    hash_identifier,
+    log_event,
+    masked,
+    merge_claims,
+    parse_jwt,
+    sanitize_scope,
+)
+
+LOGGER = logging.getLogger("sso.oidc")
+
+
+@dataclass(slots=True)
+class OIDCSettings:
+    client_id: str
+    client_secret: str
+    issuer: str
+    token_endpoint: str
+    jwks_endpoint: str
+    auth_endpoint: str
+    scopes: tuple[str, ...]
+
+
+class JWKSCache:
+    def __init__(self, *, ttl_seconds: int, clock: Clock) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._expires_at: datetime | None = None
+        self._keys: dict[str, Mapping[str, Any]] | None = None
+
+    def get(self) -> dict[str, Mapping[str, Any]] | None:
+        if self._keys is None:
+            return None
+        if self._expires_at is None:
+            return None
+        if self._clock.now() >= self._expires_at:
+            return None
+        return self._keys
+
+    def set(self, keys: dict[str, Mapping[str, Any]]) -> None:
+        self._keys = keys
+        self._expires_at = self._clock.now() + timedelta(seconds=self._ttl_seconds)
+
+
+class OIDCAdapter:
+    def __init__(
+        self,
+        settings: OIDCSettings,
+        *,
+        http_client: httpx.AsyncClient,
+        session_store: SessionStore,
+        metrics: AuthMetrics,
+        clock: Clock,
+        audit_sink: Callable[[str, str, Mapping[str, Any]], Awaitable[None]],
+        ldap_mapper: Callable[[Mapping[str, Any]], Awaitable[tuple[str, str]]] | None = None,
+        max_retries: int = 3,
+        backoff_seconds: float = 0.1,
+        jwks_ttl_seconds: int = 300,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._settings = settings
+        self._http = http_client
+        self._session_store = session_store
+        self._metrics = metrics
+        self._clock = clock
+        self._audit_sink = audit_sink
+        self._ldap_mapper = ldap_mapper
+        self._max_retries = max(1, max_retries)
+        self._backoff_seconds = backoff_seconds
+        self._jwks_cache = JWKSCache(ttl_seconds=jwks_ttl_seconds, clock=clock)
+        self._sleep = sleep or asyncio.sleep
+
+    async def authorization_url(self, *, state: str, nonce: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self._settings.client_id,
+            "redirect_uri": f"{self._settings.issuer}/callback",
+            "scope": " ".join(self._settings.scopes),
+            "state": state,
+            "nonce": nonce,
+        }
+        query = httpx.QueryParams(params)
+        return f"{self._settings.auth_endpoint}?{query}"
+
+    async def authenticate(
+        self,
+        *,
+        code: str,
+        correlation_id: str,
+        request_id: str,
+        debug: "DebugContext | None" = None,
+    ) -> BridgeSession:
+        histogram = self._metrics.duration_seconds.labels(provider="oidc")
+        with histogram.time():
+            try:
+                token_payload = await self._exchange(code, correlation_id, debug)
+                claims = await self._validate_id_token(token_payload["id_token"], correlation_id, debug)
+                claims = merge_claims(claims, token_payload.get("userinfo"))
+                role, scope = await self._map_attributes(claims, correlation_id)
+                subject = str(claims.get("sub") or claims.get("subject") or "anonymous")
+                session = await self._session_store.create(
+                    correlation_id=correlation_id,
+                    subject=subject,
+                    role=role,
+                    center_scope=scope,
+                )
+                await self._audit("AUTHN_OK", correlation_id, request_id, role=role, scope=scope)
+                self._metrics.ok_total.labels(provider="oidc").inc()
+                log_event(
+                    LOGGER,
+                    msg="OIDC_AUTH_OK",
+                    rid=request_id,
+                    cid=masked(correlation_id),
+                    role=role,
+                    scope=scope,
+                )
+                return session
+            except AuthError as exc:
+                self._metrics.fail_total.labels(provider="oidc", reason=exc.reason).inc()
+                await self._audit("AUTHN_FAIL", correlation_id, request_id, error=exc.reason)
+                if debug:
+                    debug.set_last_error(code=exc.code, message=exc.message_fa)
+                log_event(
+                    LOGGER,
+                    msg="OIDC_AUTH_FAIL",
+                    rid=request_id,
+                    cid=masked(correlation_id),
+                    error=exc.reason,
+                )
+                raise
+
+    async def _exchange(
+        self,
+        code: str,
+        correlation_id: str,
+        debug: "DebugContext | None",
+    ) -> Mapping[str, Any]:
+        body = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self._settings.client_id,
+            "client_secret": self._settings.client_secret,
+            "redirect_uri": f"{self._settings.issuer}/callback",
+        }
+        last_error: Exception | None = None
+        reason = "token"
+        for attempt in range(1, self._max_retries + 1):
+            started = self._clock.now()
+            response: httpx.Response | None = None
+            try:
+                response = await self._http.post(self._settings.token_endpoint, data=body, timeout=5.0)
+                response.raise_for_status()
+                self._record_http_attempt(
+                    method="POST",
+                    url=self._settings.token_endpoint,
+                    status=response.status_code,
+                    started=started,
+                    debug=debug,
+                )
+                return response.json()
+            except Exception as exc:  # noqa: BLE001 - network errors collapsed
+                last_error = exc
+                status = response.status_code if response is not None else None
+                self._record_http_attempt(
+                    method="POST",
+                    url=self._settings.token_endpoint,
+                    status=status,
+                    started=started,
+                    debug=debug,
+                )
+                if attempt == self._max_retries:
+                    self._metrics.retry_exhaustion_total.labels(adapter="oidc", reason=reason).inc()
+                    break
+                self._metrics.retry_attempts_total.labels(adapter="oidc", reason=reason).inc()
+                delay = exponential_backoff(
+                    self._backoff_seconds,
+                    attempt,
+                    jitter_seed=f"{correlation_id}:{reason}",
+                )
+                self._metrics.retry_backoff_seconds.labels(adapter="oidc", reason=reason).observe(delay)
+                await self._sleep(delay)
+        message = "خطا در ارتباط با ارائه‌دهندهٔ هویت؛ بعداً تلاش کنید."
+        if debug:
+            debug.set_last_error(code="AUTH_IDP_ERROR", message=message)
+        raise ProviderError(
+            code="AUTH_IDP_ERROR",
+            message_fa=message,
+            reason="token_exchange_failed",
+        ) from last_error
+
+    async def _validate_id_token(
+        self,
+        token: str,
+        correlation_id: str,
+        debug: "DebugContext | None",
+    ) -> Mapping[str, Any]:
+        header, payload, signature = parse_jwt(token)
+        kid = header.get("kid")
+        if not kid:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="توکن بازگشتی نامعتبر است.",
+                reason="missing_kid",
+            )
+        key_data = await self._resolve_jwks_key(str(kid), correlation_id, debug)
+        self._verify_signature(header, payload, signature, key_data)
+        self._validate_claims(payload)
+        return payload
+
+    def _verify_signature(
+        self,
+        header: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        signature: bytes,
+        key_data: Mapping[str, Any],
+    ) -> None:
+        alg = header.get("alg")
+        if alg != "HS256":
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="الگوریتم پشتیبانی نمی‌شود.",
+                reason="unsupported_alg",
+            )
+        secret = key_data.get("k")
+        if not isinstance(secret, str):
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="کلید نامعتبر است.",
+                reason="invalid_key",
+            )
+        signing_input = f"{encode_base64url(json.dumps(header).encode())}.{encode_base64url(json.dumps(payload).encode())}".encode()
+        digest = hmac.new(secret.encode("utf-8"), signing_input, digestmod="sha256").digest()
+        if not hmac.compare_digest(digest, signature):
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="توکن بازگشتی نامعتبر است.",
+                reason="bad_signature",
+            )
+
+    def _validate_claims(self, payload: Mapping[str, Any]) -> None:
+        issuer = payload.get("iss")
+        if issuer != self._settings.issuer:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="صادرکنندهٔ نامعتبر.",
+                reason="invalid_issuer",
+            )
+        audience = payload.get("aud")
+        if isinstance(audience, str):
+            audiences = {audience}
+        elif isinstance(audience, (list, tuple, set)):
+            audiences = {str(item) for item in audience}
+        else:
+            audiences = set()
+        if self._settings.client_id not in audiences:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="شناسهٔ مشتری تطابق ندارد.",
+                reason="invalid_audience",
+            )
+        now = self._clock.now().timestamp()
+        exp = float(payload.get("exp", 0))
+        nbf = float(payload.get("nbf", 0))
+        if now >= exp:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="توکن منقضی شده است.",
+                reason="expired",
+            )
+        if now < nbf:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="توکن هنوز فعال نشده است.",
+                reason="not_active",
+            )
+
+    async def _refresh_jwks(
+        self,
+        correlation_id: str,
+        debug: "DebugContext | None",
+    ) -> dict[str, Mapping[str, Any]]:
+        started = self._clock.now()
+        response: httpx.Response | None = None
+        try:
+            response = await self._http.get(self._settings.jwks_endpoint, timeout=5.0)
+            response.raise_for_status()
+            payload = response.json()
+            self._record_http_attempt(
+                method="GET",
+                url=self._settings.jwks_endpoint,
+                status=response.status_code,
+                started=started,
+                debug=debug,
+            )
+        except Exception:
+            status = response.status_code if response is not None else None
+            self._record_http_attempt(
+                method="GET",
+                url=self._settings.jwks_endpoint,
+                status=status,
+                started=started,
+                debug=debug,
+            )
+            raise
+        keys = {item["kid"]: item for item in payload.get("keys", []) if "kid" in item}
+        self._jwks_cache.set(keys)
+        log_event(
+            LOGGER,
+            msg="OIDC_JWKS_REFRESHED",
+            cid=masked(correlation_id),
+            keys=list(keys),
+        )
+        return keys
+
+    async def _resolve_jwks_key(
+        self,
+        kid: str,
+        correlation_id: str,
+        debug: "DebugContext | None",
+    ) -> Mapping[str, Any]:
+        cached = self._jwks_cache.get() or {}
+        if kid in cached:
+            return cached[kid]
+        reason = "jwks"
+        last_error: Exception | None = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                keys = await self._refresh_jwks(correlation_id, debug)
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                keys = {}
+            cached_key = keys.get(kid)
+            if cached_key:
+                return cached_key
+            if attempt == self._max_retries:
+                self._metrics.retry_exhaustion_total.labels(adapter="oidc", reason=reason).inc()
+                message = "کلیدهای امضای ورود نامعتبر/به‌روز نشده‌اند؛ لطفاً بعداً تلاش کنید."
+                if debug:
+                    debug.set_last_error(code="AUTH_JWKS_EXHAUSTED", message=message)
+                raise ProviderError(
+                    code="AUTH_JWKS_EXHAUSTED",
+                    message_fa=message,
+                    reason="jwks",
+                ) from last_error
+            self._metrics.retry_attempts_total.labels(adapter="oidc", reason=reason).inc()
+            delay = exponential_backoff(
+                self._backoff_seconds,
+                attempt,
+                jitter_seed=f"{correlation_id}:{reason}",
+            )
+            self._metrics.retry_backoff_seconds.labels(adapter="oidc", reason=reason).observe(delay)
+            await self._sleep(delay)
+        # Defensive: should never reach here due to raise above
+        raise ProviderError(
+            code="AUTH_IDP_ERROR",
+            message_fa="کلید امضای توکن یافت نشد.",
+            reason="unknown_kid",
+        )
+
+    def _record_http_attempt(
+        self,
+        *,
+        method: str,
+        url: str,
+        status: int | None,
+        started: datetime,
+        debug: "DebugContext | None",
+    ) -> None:
+        if not debug:
+            return
+        duration = max(0.0, (self._clock.now() - started).total_seconds())
+        debug.record_http_attempt(
+            method=method,
+            url=url,
+            status=status,
+            duration=duration,
+        )
+
+    async def _map_attributes(self, claims: Mapping[str, Any], correlation_id: str) -> tuple[str, str]:
+        role_raw = str(claims.get("role") or "").strip().upper()
+        scope_raw = claims.get("center_scope")
+        if self._ldap_mapper:
+            role_raw, scope_raw = await self._ldap_mapper(claims, correlation_id=correlation_id)
+        if role_raw not in {"ADMIN", "MANAGER"}:
+            raise ProviderError(
+                code="AUTH_FORBIDDEN",
+                message_fa="دسترسی مجاز نیست؛ نقش یا اسکوپ کافی نیست.",
+                reason="invalid_role",
+            )
+        try:
+            scope = "ALL" if role_raw == "ADMIN" else sanitize_scope(str(scope_raw) if scope_raw is not None else "")
+        except ValueError as exc:  # noqa: BLE001
+            raise ProviderError(
+                code="AUTH_FORBIDDEN",
+                message_fa="دسترسی مجاز نیست؛ نقش یا اسکوپ کافی نیست.",
+                reason="invalid_scope",
+            ) from exc
+        return role_raw, scope
+
+    async def _audit(self, action: str, correlation_id: str, request_id: str, **fields: Any) -> None:
+        payload = {
+            "action": action,
+            "cid": hash_identifier(correlation_id),
+            "request_id": request_id,
+            **fields,
+            "ts": self._clock.now().isoformat(),
+        }
+        await self._audit_sink(action, correlation_id, payload)
+
+
+__all__ = ["OIDCAdapter", "OIDCSettings"]

--- a/auth/saml_adapter.py
+++ b/auth/saml_adapter.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import logging
+import textwrap
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Mapping
+from xml.etree import ElementTree as ET
+
+from src.reliability.clock import Clock
+
+from .errors import AuthError, ProviderError
+from .metrics import AuthMetrics
+from .models import BridgeSession
+from .session_store import SessionStore
+from .utils import hash_identifier, log_event, masked, sanitize_scope
+
+LOGGER = logging.getLogger("sso.saml")
+
+
+@dataclass(slots=True)
+class SAMLSettings:
+    sp_entity_id: str
+    idp_metadata_xml: str
+    certificate_pem: str
+    private_key_pem: str
+    audience: str
+
+
+class SAMLAdapter:
+    def __init__(
+        self,
+        settings: SAMLSettings,
+        *,
+        session_store: SessionStore,
+        metrics: AuthMetrics,
+        clock: Clock,
+        audit_sink: Callable[[str, str, Mapping[str, Any]], Awaitable[None]],
+        ldap_mapper: Callable[[Mapping[str, Any]], Awaitable[tuple[str, str]]] | None = None,
+        max_assertion_kb: int = 250,
+    ) -> None:
+        self._settings = settings
+        self._session_store = session_store
+        self._metrics = metrics
+        self._clock = clock
+        self._audit_sink = audit_sink
+        self._ldap_mapper = ldap_mapper
+        self._max_assertion_bytes = max_assertion_kb * 1024
+
+    async def authenticate(
+        self,
+        *,
+        assertion: str,
+        correlation_id: str,
+        request_id: str,
+    ) -> BridgeSession:
+        histogram = self._metrics.duration_seconds.labels(provider="saml")
+        with histogram.time():
+            try:
+                attributes = self._parse_assertion(assertion)
+                role, scope = await self._map_attributes(attributes, correlation_id)
+                subject = str(attributes.get("NameID", "anonymous"))
+                session = await self._session_store.create(
+                    correlation_id=correlation_id,
+                    subject=subject,
+                    role=role,
+                    center_scope=scope,
+                )
+                await self._audit("AUTHN_OK", correlation_id, request_id, role=role, scope=scope)
+                self._metrics.ok_total.labels(provider="saml").inc()
+                log_event(
+                    LOGGER,
+                    msg="SAML_AUTH_OK",
+                    rid=request_id,
+                    cid=masked(correlation_id),
+                    role=role,
+                )
+                return session
+            except AuthError as exc:
+                self._metrics.fail_total.labels(provider="saml", reason=exc.reason).inc()
+                await self._audit("AUTHN_FAIL", correlation_id, request_id, error=exc.reason)
+                log_event(
+                    LOGGER,
+                    msg="SAML_AUTH_FAIL",
+                    rid=request_id,
+                    cid=masked(correlation_id),
+                    error=exc.reason,
+                )
+                raise
+
+    def _parse_assertion(self, assertion: str) -> Mapping[str, Any]:
+        data = textwrap.dedent(assertion.strip())
+        encoded = data.encode("utf-8")
+        if len(encoded) > self._max_assertion_bytes:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="پیام هویتی بسیار بزرگ است.",
+                reason="assertion_too_large",
+            )
+        try:
+            root = ET.fromstring(data)
+        except ET.ParseError as exc:  # noqa: BLE001
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="پیام هویتی نامعتبر است.",
+                reason="parse_error",
+            ) from exc
+        conditions = root.find(".//{*}Conditions")
+        if conditions is None:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="پیام هویتی شرایط ندارد.",
+                reason="missing_conditions",
+            )
+        self._validate_conditions(conditions)
+        attributes: dict[str, Any] = {}
+        name_id = root.findtext(".//{*}NameID")
+        if name_id:
+            attributes["NameID"] = name_id
+        for attr in root.findall(".//{*}Attribute"):
+            key = attr.get("Name") or attr.get("FriendlyName")
+            if not key:
+                continue
+            values = [value.text or "" for value in attr.findall("{*}AttributeValue")]
+            attributes[key] = values[0] if len(values) == 1 else values
+        return attributes
+
+    def _validate_conditions(self, conditions: ET.Element) -> None:
+        audience = conditions.findtext(".//{*}Audience")
+        if audience != self._settings.audience:
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="شناسهٔ مخاطب همخوانی ندارد.",
+                reason="invalid_audience",
+            )
+        not_before = conditions.get("NotBefore")
+        not_on_or_after = conditions.get("NotOnOrAfter")
+        now = self._clock.now()
+        if not_before:
+            start = self._parse_datetime(not_before)
+            if now < start:
+                raise ProviderError(
+                    code="AUTH_IDP_ERROR",
+                    message_fa="پیام هویتی هنوز معتبر نیست.",
+                    reason="not_before",
+                )
+        if not_on_or_after:
+            end = self._parse_datetime(not_on_or_after)
+            if now >= end:
+                raise ProviderError(
+                    code="AUTH_IDP_ERROR",
+                    message_fa="پیام هویتی منقضی شده است.",
+                    reason="expired",
+                )
+
+    async def _map_attributes(
+        self,
+        attributes: Mapping[str, Any],
+        correlation_id: str,
+    ) -> tuple[str, str]:
+        role_raw = str(attributes.get("role") or "").strip().upper()
+        scope_raw = attributes.get("center_scope")
+        if self._ldap_mapper:
+            role_raw, scope_raw = await self._ldap_mapper(attributes, correlation_id=correlation_id)
+        if role_raw not in {"ADMIN", "MANAGER"}:
+            raise ProviderError(
+                code="AUTH_FORBIDDEN",
+                message_fa="دسترسی مجاز نیست؛ نقش یا اسکوپ کافی نیست.",
+                reason="invalid_role",
+            )
+        try:
+            scope = "ALL" if role_raw == "ADMIN" else sanitize_scope(str(scope_raw) if scope_raw is not None else "")
+        except ValueError as exc:  # noqa: BLE001
+            raise ProviderError(
+                code="AUTH_FORBIDDEN",
+                message_fa="دسترسی مجاز نیست؛ نقش یا اسکوپ کافی نیست.",
+                reason="invalid_scope",
+            ) from exc
+        return role_raw, scope
+
+    async def _audit(self, action: str, correlation_id: str, request_id: str, **fields: Any) -> None:
+        payload = {
+            "action": action,
+            "cid": hash_identifier(correlation_id),
+            "request_id": request_id,
+            **fields,
+            "ts": self._clock.now().isoformat(),
+        }
+        await self._audit_sink(action, correlation_id, payload)
+
+    def _parse_datetime(self, value: str) -> datetime:
+        normalized = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+
+
+__all__ = ["SAMLAdapter", "SAMLSettings"]

--- a/auth/session_store.py
+++ b/auth/session_store.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from typing import Any, Protocol
+
+from src.reliability.clock import Clock
+
+from .errors import ProviderError
+from .models import BridgeSession
+from .utils import build_sid, log_event
+
+LOGGER = logging.getLogger("sso.session")
+
+
+class SessionSerializer(Protocol):
+    def dumps(self, session: BridgeSession) -> str: ...
+
+    def loads(self, payload: str) -> BridgeSession: ...
+
+
+class JSONSessionSerializer:
+    def dumps(self, session: BridgeSession) -> str:
+        payload = asdict(session)
+        payload["issued_at"] = session.issued_at.isoformat()
+        payload["expires_at"] = session.expires_at.isoformat()
+        return json.dumps(payload)
+
+    def loads(self, payload: str) -> BridgeSession:
+        data = json.loads(payload)
+        return BridgeSession(
+            sid=data["sid"],
+            role=data["role"],
+            center_scope=data["center_scope"],
+            issued_at=datetime.fromisoformat(data["issued_at"]),
+            expires_at=datetime.fromisoformat(data["expires_at"]),
+        )
+
+
+class SessionStore:
+    """Redis-backed bridge session repository."""
+
+    def __init__(
+        self,
+        redis: Any,
+        *,
+        ttl_seconds: int,
+        clock: Clock,
+        namespace: str = "sso_session",
+        serializer: SessionSerializer | None = None,
+    ) -> None:
+        self._redis = redis
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._namespace = namespace
+        self._serializer = serializer or JSONSessionSerializer()
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl_seconds
+
+    def _key(self, sid: str) -> str:
+        return f"{self._namespace}:{sid}"
+
+    async def create(
+        self,
+        *,
+        correlation_id: str,
+        subject: str,
+        role: str,
+        center_scope: str,
+    ) -> BridgeSession:
+        sid = build_sid(correlation_id, subject, clock=self._clock)
+        issued_at = self._clock.now()
+        expires_at = issued_at + timedelta(seconds=self._ttl_seconds)
+        session = BridgeSession(
+            sid=sid,
+            role=role,  # type: ignore[arg-type]
+            center_scope=center_scope,
+            issued_at=issued_at,
+            expires_at=expires_at,
+        )
+        payload = self._serializer.dumps(session)
+        key = self._key(sid)
+        result = self._redis.set(key, payload, ex=self._ttl_seconds, nx=True)
+        ok = await result if hasattr(result, "__await__") else result
+        if not ok:
+            log_event(LOGGER, msg="SSO_SESSION_COLLISION", sid=sid)
+            raise ProviderError(
+                code="AUTH_IDP_ERROR",
+                message_fa="خطا در ایجاد نشست؛ بعداً تلاش کنید.",
+                reason="session_collision",
+            )
+        log_event(
+            LOGGER,
+            msg="SSO_SESSION_CREATED",
+            sid=sid,
+            ttl=self._ttl_seconds,
+        )
+        return session
+
+    async def get(self, sid: str) -> BridgeSession | None:
+        result = self._redis.get(self._key(sid))
+        payload = await result if hasattr(result, "__await__") else result
+        if payload is None:
+            return None
+        data = payload.decode("utf-8") if isinstance(payload, (bytes, bytearray)) else payload
+        session = self._serializer.loads(data)
+        return session
+
+    async def delete(self, sid: str) -> None:
+        result = self._redis.delete(self._key(sid))
+        if hasattr(result, "__await__"):
+            await result
+
+
+__all__ = ["SessionStore", "JSONSessionSerializer"]

--- a/auth/utils.py
+++ b/auth/utils.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from datetime import datetime, timedelta
+from typing import Iterable, Mapping
+
+from src.reliability.clock import Clock
+
+LOGGER = logging.getLogger("sso")
+
+_DIGIT_MAP = str.maketrans(
+    {
+        "۰": "0",
+        "۱": "1",
+        "۲": "2",
+        "۳": "3",
+        "۴": "4",
+        "۵": "5",
+        "۶": "6",
+        "۷": "7",
+        "۸": "8",
+        "۹": "9",
+        "٠": "0",
+        "١": "1",
+        "٢": "2",
+        "٣": "3",
+        "٤": "4",
+        "٥": "5",
+        "٦": "6",
+        "٧": "7",
+        "٨": "8",
+        "٩": "9",
+    }
+)
+
+
+def fold_digits(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value.translate(_DIGIT_MAP)
+
+
+def sanitize_scope(value: str | None) -> str:
+    candidate = fold_digits((value or "").strip()) or "ALL"
+    candidate = "".join(ch for ch in candidate if ch.isalnum())
+    if candidate.upper() == "ALL":
+        return "ALL"
+    digits = "".join(ch for ch in candidate if ch.isdigit())
+    if not digits:
+        raise ValueError("invalid scope")
+    if len(digits) > 6:
+        raise ValueError("invalid scope length")
+    return digits
+
+
+def hash_identifier(*values: str) -> str:
+    digest = hashlib.blake2b(digest_size=12)
+    for value in values:
+        digest.update(value.encode("utf-8", errors="ignore"))
+    return digest.hexdigest()
+
+
+def masked(value: str | None) -> str:
+    if not value:
+        return "*"
+    return hash_identifier(value)[:8]
+
+
+def deterministic_jitter(seed: str, attempt: int) -> float:
+    digest = hashlib.blake2b(digest_size=6)
+    digest.update(seed.encode("utf-8"))
+    digest.update(str(attempt).encode("ascii"))
+    integer = int.from_bytes(digest.digest(), "big")
+    return (integer % 37) / 100.0  # milliseconds component converted to seconds
+
+
+def exponential_backoff(base: float, attempt: int, *, jitter_seed: str) -> float:
+    delay = base * (2**max(0, attempt - 1))
+    return delay + deterministic_jitter(jitter_seed, attempt)
+
+
+def decode_base64url(segment: str) -> bytes:
+    padding = "=" * (-len(segment) % 4)
+    return urlsafe_b64decode(segment + padding)
+
+
+def encode_base64url(data: bytes) -> str:
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def parse_jwt(token: str) -> tuple[dict, dict, bytes]:
+    header_b64, payload_b64, signature_b64 = token.split(".")
+    header = json.loads(decode_base64url(header_b64))
+    payload = json.loads(decode_base64url(payload_b64))
+    signature = decode_base64url(signature_b64)
+    return header, payload, signature
+
+
+def utcnow(clock: Clock) -> datetime:
+    return clock.now()
+
+
+def ttl_from(clock: Clock, minutes: int) -> datetime:
+    return clock.now() + timedelta(minutes=minutes)
+
+
+def build_sid(correlation_id: str, subject: str, *, clock: Clock) -> str:
+    seed = f"{correlation_id}:{subject}:{clock.now().timestamp()}"
+    return hash_identifier(seed)[:24]
+
+
+def merge_claims(*sources: Mapping[str, object] | None) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for source in sources:
+        if not source:
+            continue
+        for key, value in source.items():
+            if value is None:
+                continue
+            result[key] = value
+    return result
+
+
+def log_event(logger: logging.Logger, *, msg: str, **extra: object) -> None:
+    logger.info(msg, extra=extra)
+
+
+def redact_attributes(attrs: Mapping[str, object]) -> Mapping[str, object]:
+    redacted: dict[str, object] = {}
+    for key, value in attrs.items():
+        if isinstance(value, str):
+            redacted[key] = masked(value)
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def ensure_no_pii(payload: Mapping[str, object], *, forbidden_keys: Iterable[str]) -> None:
+    for key in forbidden_keys:
+        if key in payload and isinstance(payload[key], str) and "@" in payload[key]:
+            raise ValueError("PII detected")

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,3 @@
+"""Application-level helpers shared across entrypoints."""
+
+__all__ = []

--- a/src/app/bootstrap_logging.py
+++ b/src/app/bootstrap_logging.py
@@ -1,0 +1,34 @@
+"""Bootstrap structured logging with optional debug context enrichment."""
+from __future__ import annotations
+
+import logging
+import os
+
+from src.logging.json_logger import register_log_enricher
+
+_ENV_FLAG = "DEBUG_CONTEXT_ENABLE"
+
+
+def bootstrap_logging(*, enable: bool | None = None) -> None:
+    """Configure root logging handlers with the debug context enricher."""
+
+    if not _should_enable(enable):
+        return
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        root_logger.addHandler(handler)
+    register_log_enricher(root_logger)
+
+
+def _should_enable(explicit: bool | None) -> bool:
+    if explicit is not None:
+        return explicit
+    raw = os.getenv(_ENV_FLAG)
+    if raw is not None:
+        return raw.lower() in {"1", "true", "yes", "on"}
+    return bool(os.getenv("PYTEST_CURRENT_TEST"))
+
+
+__all__ = ["bootstrap_logging"]

--- a/src/app/context.py
+++ b/src/app/context.py
@@ -1,0 +1,33 @@
+"""Context management helpers for request-scoped debug data."""
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from src.debug.debug_context import DebugContext
+
+_DEBUG_CONTEXT: ContextVar["DebugContext | None"] = ContextVar(
+    "debug_context", default=None
+)
+
+
+def set_debug_context(ctx: "DebugContext | None") -> Token["DebugContext | None"]:
+    """Bind the provided debug context to the current execution context."""
+
+    return _DEBUG_CONTEXT.set(ctx)
+
+
+def reset_debug_context(token: Token["DebugContext | None"]) -> None:
+    """Restore the debug context to a previous state."""
+
+    _DEBUG_CONTEXT.reset(token)
+
+
+def get_debug_context() -> "DebugContext | None":
+    """Return the currently bound debug context, if any."""
+
+    return _DEBUG_CONTEXT.get()
+
+
+__all__ = ["set_debug_context", "reset_debug_context", "get_debug_context"]

--- a/src/config/env_schema.py
+++ b/src/config/env_schema.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping
+
+from auth.ldap_adapter import LdapSettings
+from auth.oidc_adapter import OIDCSettings
+from auth.saml_adapter import SAMLSettings
+
+
+@dataclass(slots=True)
+class SSOConfig:
+    enabled: bool
+    session_ttl_seconds: int
+    blue_green_state: str
+    oidc: OIDCSettings | None
+    saml: SAMLSettings | None
+    ldap: LdapSettings | None
+
+    @property
+    def post_ready(self) -> bool:
+        return self.blue_green_state in {"green", "active"}
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> "SSOConfig":
+        mutable = dict(env)
+        _reject_unknown(mutable.keys())
+        enabled = _read_bool(mutable.get("SSO_ENABLED", "false"), "SSO_ENABLED")
+        ttl_seconds = _read_int(mutable.get("SSO_SESSION_TTL_SECONDS", "900"), "SSO_SESSION_TTL_SECONDS")
+        blue_green_state = mutable.get("SSO_BLUE_GREEN_STATE", "blue").lower()
+        if blue_green_state not in {"blue", "green", "active", "warming"}:
+            raise ValueError(f"«نوع مقدار نامعتبر است: SSO_BLUE_GREEN_STATE»")
+
+        oidc = _parse_oidc(mutable) if enabled else None
+        saml = _parse_saml(mutable) if enabled else None
+        if enabled and not (oidc or saml):
+            raise ValueError("«کلید الزامی مفقود: OIDC_CLIENT_ID|SAML_SP_ENTITY_ID»")
+        ldap = _parse_ldap(mutable)
+        return cls(
+            enabled=enabled,
+            session_ttl_seconds=ttl_seconds,
+            blue_green_state=blue_green_state,
+            oidc=oidc,
+            saml=saml,
+            ldap=ldap,
+        )
+
+
+_ALLOWED_KEYS = {
+    "SSO_ENABLED",
+    "SSO_SESSION_TTL_SECONDS",
+    "SSO_BLUE_GREEN_STATE",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_ISSUER",
+    "OIDC_SCOPES",
+    "OIDC_TOKEN_ENDPOINT",
+    "OIDC_AUTH_ENDPOINT",
+    "OIDC_JWKS_ENDPOINT",
+    "SAML_SP_ENTITY_ID",
+    "SAML_IDP_METADATA_XML",
+    "SAML_SP_CERT_PEM",
+    "SAML_SP_KEY_PEM",
+    "SAML_AUDIENCE",
+    "LDAP_URL",
+    "LDAP_BIND_DN",
+    "LDAP_BIND_PASSWORD",
+    "LDAP_BASE_DN",
+    "LDAP_GROUP_ATTR",
+    "LDAP_TIMEOUT_SEC",
+    "LDAP_GROUP_RULES",
+}
+
+
+def _reject_unknown(keys: Iterable[str]) -> None:
+    for key in keys:
+        if key not in _ALLOWED_KEYS:
+            raise ValueError(f"«کلید ناشناخته: {key}»")
+
+
+def _parse_oidc(env: MutableMapping[str, str]) -> OIDCSettings | None:
+    client_id = env.get("OIDC_CLIENT_ID")
+    client_secret = env.get("OIDC_CLIENT_SECRET")
+    issuer = env.get("OIDC_ISSUER")
+    scopes_raw = env.get("OIDC_SCOPES")
+    token_endpoint = env.get("OIDC_TOKEN_ENDPOINT") or (f"{issuer}/token" if issuer else None)
+    auth_endpoint = env.get("OIDC_AUTH_ENDPOINT") or (f"{issuer}/authorize" if issuer else None)
+    jwks_endpoint = env.get("OIDC_JWKS_ENDPOINT") or (f"{issuer}/jwks" if issuer else None)
+    required = {
+        "OIDC_CLIENT_ID": client_id,
+        "OIDC_CLIENT_SECRET": client_secret,
+        "OIDC_ISSUER": issuer,
+        "OIDC_SCOPES": scopes_raw,
+    }
+    if not any(required.values()):
+        return None
+    for key, value in required.items():
+        if not value:
+            raise ValueError(f"«کلید الزامی مفقود: {key}»")
+    scopes = tuple(part for part in scopes_raw.split() if part)
+    if not scopes:
+        raise ValueError("«نوع مقدار نامعتبر است: OIDC_SCOPES»")
+    return OIDCSettings(
+        client_id=client_id,
+        client_secret=client_secret,
+        issuer=issuer.rstrip("/"),
+        token_endpoint=token_endpoint or f"{issuer}/token",
+        jwks_endpoint=jwks_endpoint or f"{issuer}/jwks",
+        auth_endpoint=auth_endpoint or f"{issuer}/authorize",
+        scopes=scopes,
+    )
+
+
+def _parse_saml(env: MutableMapping[str, str]) -> SAMLSettings | None:
+    entity_id = env.get("SAML_SP_ENTITY_ID")
+    metadata_xml = env.get("SAML_IDP_METADATA_XML")
+    cert_pem = env.get("SAML_SP_CERT_PEM")
+    key_pem = env.get("SAML_SP_KEY_PEM")
+    audience = env.get("SAML_AUDIENCE") or entity_id
+    if not entity_id and not metadata_xml:
+        return None
+    required = {
+        "SAML_SP_ENTITY_ID": entity_id,
+        "SAML_IDP_METADATA_XML": metadata_xml,
+        "SAML_SP_CERT_PEM": cert_pem,
+        "SAML_SP_KEY_PEM": key_pem,
+    }
+    for key, value in required.items():
+        if not value:
+            raise ValueError(f"«کلید الزامی مفقود: {key}»")
+    return SAMLSettings(
+        sp_entity_id=entity_id,
+        idp_metadata_xml=metadata_xml,
+        certificate_pem=cert_pem,
+        private_key_pem=key_pem,
+        audience=audience or entity_id,
+    )
+
+
+def _parse_ldap(env: MutableMapping[str, str]) -> LdapSettings | None:
+    timeout = env.get("LDAP_TIMEOUT_SEC")
+    rules_raw = env.get("LDAP_GROUP_RULES")
+    if not any(key.startswith("LDAP_") for key in env):
+        return None
+    group_rules: dict[str, tuple[str, str]] = {}
+    if rules_raw:
+        for item in rules_raw.split(","):
+            if not item.strip():
+                continue
+            try:
+                group, role, scope = item.split(":", 2)
+            except ValueError as exc:  # noqa: BLE001
+                raise ValueError("«نوع مقدار نامعتبر است: LDAP_GROUP_RULES»") from exc
+            group_rules[group.strip()] = (role.strip().upper(), scope.strip())
+    try:
+        timeout_value = float(timeout) if timeout else 3.0
+    except ValueError as exc:  # noqa: BLE001
+        raise ValueError("«نوع مقدار نامعتبر است: LDAP_TIMEOUT_SEC»") from exc
+    return LdapSettings(timeout_seconds=timeout_value, group_rules=group_rules)
+
+
+def _read_bool(value: str, key: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes"}:
+        return True
+    if normalized in {"0", "false", "no", ""}:
+        return False
+    raise ValueError(f"«نوع مقدار نامعتبر است: {key}»")
+
+
+def _read_int(value: str, key: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:  # noqa: BLE001
+        raise ValueError(f"«نوع مقدار نامعتبر است: {key}»") from exc
+
+
+__all__ = ["SSOConfig"]

--- a/src/debug/__init__.py
+++ b/src/debug/__init__.py
@@ -1,0 +1,3 @@
+from .debug_context import DebugContext, DebugContextFactory, default_debug_context_factory
+
+__all__ = ["DebugContext", "DebugContextFactory", "default_debug_context_factory"]

--- a/src/debug/debug_context.py
+++ b/src/debug/debug_context.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from hashlib import blake2b
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from src.app.context import set_debug_context
+
+
+_ALLOWED_PREFIXES = ("sso_session:", "idem:", "ratelimit:")
+_PII_PATTERN = re.compile(r"email|phone|national_id", re.IGNORECASE)
+
+
+def _hash_text(value: str) -> str:
+    digest = blake2b(digest_size=16)
+    digest.update(value.encode("utf-8", errors="ignore"))
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class DebugContext:
+    """Collect deterministic debug information for assertions and logs."""
+
+    rid: str
+    operation: str
+    namespace: str
+    redis_scan: Callable[[str], Iterable[str]] | None = None
+    audit_events: Callable[[], Sequence[Mapping[str, Any]]] | None = None
+    http_attempts: list[Mapping[str, Any]] = field(default_factory=list)
+    last_error: Mapping[str, Any] | None = None
+
+    def record_http_attempt(
+        self,
+        *,
+        method: str,
+        url: str,
+        status: int | None,
+        duration: float,
+    ) -> None:
+        attempt = {
+            "method": method.upper(),
+            "url": url,
+            "status": status if status is not None else -1,
+            "duration": round(duration, 6),
+        }
+        self.http_attempts.append(attempt)
+
+    def set_last_error(self, *, code: str, message: str | None = None) -> None:
+        masked_message = _hash_text(message) if message else None
+        self.last_error = {"code": code, "message": masked_message}
+
+    def snapshot(self) -> dict[str, Any]:
+        data = {
+            "rid": self.rid,
+            "operation": self.operation,
+            "namespace": self.namespace,
+            "redis_keys": self._collect_redis_keys(),
+            "audit_events": self._collect_audit_events(),
+            "http_attempts": list(self.http_attempts),
+            "last_error": self.last_error,
+        }
+        self._ensure_no_pii(data)
+        return data
+
+    def to_json(self) -> str:
+        return json.dumps(self.snapshot(), ensure_ascii=False, sort_keys=True)
+
+    def as_json(self) -> str:
+        """Alias used by logging enrichers expecting explicit naming."""
+
+        return self.to_json()
+
+    def _collect_redis_keys(self) -> list[str]:
+        if not self.redis_scan:
+            return []
+        collected: set[str] = set()
+        for prefix in _ALLOWED_PREFIXES:
+            pattern = f"{prefix}*"
+            for key in self.redis_scan(pattern):
+                if isinstance(key, bytes):
+                    key = key.decode("utf-8", errors="ignore")
+                if not isinstance(key, str):
+                    continue
+                if any(key.startswith(p) for p in _ALLOWED_PREFIXES):
+                    collected.add(key)
+        return sorted(collected)
+
+    def _collect_audit_events(self) -> list[dict[str, Any]]:
+        if not self.audit_events:
+            return []
+        events = list(self.audit_events())[-5:]
+        sanitized: list[dict[str, Any]] = []
+        for event in events:
+            action = event.get("action")
+            cid = event.get("cid")
+            correlation = event.get("correlation_id")
+            sanitized.append(
+                {
+                    "action": action,
+                    "cid": cid or (_hash_text(str(correlation)) if correlation else None),
+                    "ts": event.get("ts"),
+                }
+            )
+        return sanitized
+
+    def _ensure_no_pii(self, payload: Mapping[str, Any]) -> None:
+        dump = json.dumps(payload, ensure_ascii=False)
+        if _PII_PATTERN.search(dump):
+            raise ValueError("PII detected in debug context")
+
+
+@dataclass(slots=True)
+class DebugContextFactory:
+    """Factory that binds :class:`DebugContext` to the logging context."""
+
+    redis: Any | None = None
+    audit_fetcher: Callable[[], Sequence[Mapping[str, Any]]] | None = None
+    namespace: str | None = None
+
+    def __call__(
+        self,
+        request: Any | None = None,
+        *,
+        rid: str | None = None,
+        operation: str | None = None,
+        namespace: str | None = None,
+    ) -> DebugContext:
+        resolved_rid = rid or self._resolve_rid(request)
+        resolved_operation = operation or self._resolve_operation(request)
+        resolved_namespace = namespace or self._resolve_namespace(request)
+        ctx = DebugContext(
+            rid=resolved_rid,
+            operation=resolved_operation,
+            namespace=resolved_namespace,
+            redis_scan=self._build_redis_scanner(),
+            audit_events=self._build_audit_fetcher(),
+        )
+        token = set_debug_context(ctx)
+        if request is not None and hasattr(request, "state"):
+            setattr(request.state, "debug_ctx", ctx)
+            setattr(request.state, "debug_ctx_token", token)
+        return ctx
+
+    def _build_redis_scanner(self) -> Callable[[str], Iterable[str]] | None:
+        client = self.redis
+        if client is None:
+            return None
+
+        def scanner(pattern: str) -> Iterable[str]:
+            try:
+                iterator = getattr(client, "scan_iter", None)
+                if iterator is None:
+                    return []
+                result = iterator(match=pattern)
+                if hasattr(result, "__await__"):
+                    return []
+                if hasattr(result, "__aiter__"):
+                    return []
+                return list(result)
+            except Exception:
+                return []
+
+        return scanner
+
+    def _build_audit_fetcher(self) -> Callable[[], Sequence[Mapping[str, Any]]] | None:
+        if self.audit_fetcher is None:
+            return None
+
+        def loader() -> Sequence[Mapping[str, Any]]:
+            try:
+                events = list(self.audit_fetcher())
+            except Exception:
+                return []
+            sanitized: list[dict[str, Any]] = []
+            for event in events:
+                sanitized.append(
+                    {
+                        "id": event.get("id"),
+                        "action": event.get("action"),
+                        "correlation_id": event.get("correlation_id"),
+                        "ts": event.get("ts"),
+                    }
+                )
+            return sanitized
+
+        return loader
+
+    def _resolve_rid(self, request: Any | None) -> str:
+        if request is None:
+            return "anonymous"
+        headers = getattr(request, "headers", None)
+        if headers:
+            value = headers.get("X-Request-ID") if hasattr(headers, "get") else None
+            if value:
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+        state = getattr(request, "state", None)
+        if state is not None and getattr(state, "rid", None):
+            return getattr(state, "rid")
+        return "anonymous"
+
+    def _resolve_operation(self, request: Any | None) -> str:
+        if request is None:
+            return "unknown"
+        scope = getattr(request, "scope", {}) or {}
+        endpoint = scope.get("endpoint") if isinstance(scope, dict) else None
+        if endpoint is not None:
+            name = getattr(endpoint, "__name__", None)
+            if name:
+                return name
+        path = scope.get("path") if isinstance(scope, dict) else None
+        if path:
+            return str(path)
+        url = getattr(request, "url", None)
+        if url:
+            return str(url)
+        method = getattr(request, "method", None)
+        if method:
+            return str(method)
+        return "unknown"
+
+    def _resolve_namespace(self, request: Any | None) -> str:
+        if namespace := self.namespace:
+            return namespace
+        if request is None:
+            return "debug"
+        scope = getattr(request, "scope", {}) or {}
+        endpoint = scope.get("endpoint") if isinstance(scope, dict) else None
+        if endpoint is not None:
+            module = getattr(endpoint, "__module__", None)
+            if module:
+                return module
+        app = getattr(request, "app", None)
+        if app is not None:
+            title = getattr(app, "title", None)
+            if title:
+                return str(title)
+        return "debug"
+
+
+def default_debug_context_factory(
+    *,
+    redis: Any | None,
+    audit_fetcher: Callable[[], Sequence[Mapping[str, Any]]] | None = None,
+    namespace: str | None = None,
+) -> DebugContextFactory:
+    """Convenience helper for configuring the default factory."""
+
+    return DebugContextFactory(redis=redis, audit_fetcher=audit_fetcher, namespace=namespace)
+
+
+__all__ = [
+    "DebugContext",
+    "DebugContextFactory",
+    "default_debug_context_factory",
+]

--- a/src/logging/__init__.py
+++ b/src/logging/__init__.py
@@ -1,0 +1,5 @@
+"""Logging utilities with JSON enrichment."""
+
+from .json_logger import LogEnricher
+
+__all__ = ["LogEnricher"]

--- a/src/logging/json_logger.py
+++ b/src/logging/json_logger.py
@@ -1,0 +1,45 @@
+"""JSON logging enrichers for attaching debug context snapshots."""
+from __future__ import annotations
+
+import json
+import logging
+
+from src.app.context import get_debug_context
+
+
+class LogEnricher(logging.Filter):
+    """Logging filter that injects the active debug context into records."""
+
+    def __init__(self, *, field_name: str = "debug_context") -> None:
+        super().__init__()
+        self._field_name = field_name
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - exercised via tests
+        payload = self._serialize_context()
+        setattr(record, self._field_name, payload)
+        return True
+
+    def _serialize_context(self) -> str:
+        ctx = get_debug_context()
+        if ctx is None:
+            return "{}"
+        try:
+            return ctx.as_json()
+        except Exception:
+            return json.dumps({"error": "context_unavailable"}, ensure_ascii=False, sort_keys=True)
+
+
+def register_log_enricher(logger: logging.Logger, *, field_name: str = "debug_context") -> LogEnricher:
+    """Attach the :class:`LogEnricher` filter to the provided logger."""
+
+    for existing in logger.filters:
+        if isinstance(existing, LogEnricher) and getattr(existing, "_field_name", field_name) == field_name:
+            return existing
+    enricher = LogEnricher(field_name=field_name)
+    logger.addFilter(enricher)
+    for handler in list(logger.handlers):
+        handler.addFilter(enricher)
+    return enricher
+
+
+__all__ = ["LogEnricher", "register_log_enricher"]

--- a/src/security/sso_app.py
+++ b/src/security/sso_app.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from typing import Any, Awaitable, Callable, Mapping
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from auth.errors import AuthError
+from auth.metrics import AuthMetrics
+from auth.oidc_adapter import OIDCAdapter
+from auth.saml_adapter import SAMLAdapter
+from auth.session_store import SessionStore
+from config.env_schema import SSOConfig
+from src.app.context import reset_debug_context
+from src.debug.debug_context import DebugContext
+from src.reliability.clock import Clock
+
+_HTTP_STATUS_TOO_MANY_REQUESTS = 429
+_HTTP_STATUS_SERVICE_UNAVAILABLE = 503
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, *, limit: int, window_seconds: float, clock: Clock) -> None:
+        super().__init__(app)
+        self._limit = limit
+        self._window_seconds = window_seconds
+        self._clock = clock
+        self._state: dict[str, tuple[int, float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Any]]) -> Any:
+        request.state.middleware_order = getattr(request.state, "middleware_order", []) + ["RateLimit"]
+        key = request.headers.get("X-RateLimit-Key") or request.client.host or "global"
+        now = self._clock.now().timestamp()
+        async with self._lock:
+            count, reset_at = self._state.get(key, (0, now + self._window_seconds))
+            if now >= reset_at:
+                count = 0
+                reset_at = now + self._window_seconds
+            if count >= self._limit and request.method == "POST":
+                raise HTTPException(status_code=_HTTP_STATUS_TOO_MANY_REQUESTS, detail="نرخ درخواست مجاز نیست.")
+            self._state[key] = (count + 1, reset_at)
+        return await call_next(request)
+
+
+class IdempotencyMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, *, ttl_seconds: int, clock: Clock) -> None:
+        super().__init__(app)
+        self._ttl = ttl_seconds
+        self._clock = clock
+        self._responses: dict[str, tuple[bytes, float, dict[str, str]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Any]]) -> Any:
+        request.state.middleware_order = getattr(request.state, "middleware_order", []) + ["Idempotency"]
+        if request.method != "POST":
+            return await call_next(request)
+        key = request.headers.get("Idempotency-Key")
+        if not key:
+            raise HTTPException(status_code=400, detail="کلید تکرار الزامی است.")
+        now = self._clock.now().timestamp()
+        async with self._lock:
+            cached = self._responses.get(key)
+            if cached and cached[1] + self._ttl > now:
+                body, _, headers = cached
+                response = JSONResponse(content=json.loads(body.decode("utf-8")))
+                response.headers.update(headers)
+                response.headers["X-Middleware-Order"] = ",".join(request.state.middleware_order)
+                return response
+        response = await call_next(request)
+        body = b""
+        async for chunk in response.body_iterator:
+            body += chunk
+        headers = dict(response.headers)
+        async with self._lock:
+            self._responses[key] = (body, now, headers)
+        replay = JSONResponse(content=json.loads(body.decode("utf-8")), status_code=response.status_code, headers=headers)
+        replay.headers["X-Middleware-Order"] = ",".join(request.state.middleware_order)
+        return replay
+
+
+class CallbackAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, *, config: SSOConfig) -> None:
+        super().__init__(app)
+        self._config = config
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Any]]) -> Any:
+        request.state.middleware_order = getattr(request.state, "middleware_order", []) + ["Auth"]
+        if request.method == "POST" and not self._config.post_ready:
+            response = JSONResponse(
+                {"detail": "سامانه در حالت آماده‌سازی است."},
+                status_code=_HTTP_STATUS_SERVICE_UNAVAILABLE,
+            )
+            order = getattr(request.state, "middleware_order", [])
+            if order:
+                response.headers["X-Middleware-Order"] = ",".join(order)
+            return response
+        return await call_next(request)
+
+
+def _resolve_correlation_id(request: Request) -> str:
+    header = request.headers.get("X-Request-ID")
+    if header and header.strip():
+        return header.strip()
+    return uuid.uuid4().hex
+
+
+def create_sso_app(
+    *,
+    config: SSOConfig,
+    clock: Clock,
+    session_store: SessionStore,
+    metrics: AuthMetrics,
+    audit_sink: Callable[[str, str, Mapping[str, Any]], Awaitable[None]],
+    http_client: httpx.AsyncClient,
+    ldap_mapper: Callable[[Mapping[str, Any]], Awaitable[tuple[str, str]]] | None,
+    metrics_token: str,
+    debug_context_factory: Callable[[Request], DebugContext] | None = None,
+) -> FastAPI:
+    app = FastAPI()
+
+    # Register middlewares in reverse order to satisfy RateLimit -> Idempotency -> Auth execution
+    app.add_middleware(CallbackAuthMiddleware, config=config)
+    app.add_middleware(IdempotencyMiddleware, ttl_seconds=config.session_ttl_seconds, clock=clock)
+    app.add_middleware(RateLimitMiddleware, limit=30, window_seconds=1.0, clock=clock)
+
+    oidc_adapter = OIDCAdapter(
+        settings=config.oidc,
+        http_client=http_client,
+        session_store=session_store,
+        metrics=metrics,
+        clock=clock,
+        audit_sink=audit_sink,
+        ldap_mapper=ldap_mapper,
+    ) if config.oidc else None
+
+    saml_adapter = SAMLAdapter(
+        settings=config.saml,
+        session_store=session_store,
+        metrics=metrics,
+        clock=clock,
+        audit_sink=audit_sink,
+        ldap_mapper=ldap_mapper,
+    ) if config.saml else None
+
+    @app.get("/auth/login")
+    async def login(request: Request, provider: str | None = None) -> JSONResponse:
+        correlation_id = _resolve_correlation_id(request)
+        chosen = provider or ("oidc" if oidc_adapter else "saml")
+        if chosen == "oidc" and oidc_adapter:
+            url = await oidc_adapter.authorization_url(state=correlation_id, nonce=uuid.uuid4().hex)
+        elif chosen == "saml" and saml_adapter:
+            url = f"{config.saml.idp_metadata_xml}#login"
+        else:
+            raise HTTPException(status_code=400, detail="ارائه‌دهنده نامعتبر است.")
+        response = JSONResponse({"url": url, "provider": chosen})
+        response.set_cookie(
+            "sso_state",
+            value=correlation_id,
+            max_age=300,
+            httponly=True,
+            samesite="lax",
+            secure=os.getenv("ENVIRONMENT") == "production",
+        )
+        return response
+
+    @app.post("/auth/callback")
+    async def callback(request: Request) -> JSONResponse:
+        body = await request.json()
+        provider = body.get("provider") or ("oidc" if "code" in body else "saml")
+        correlation_id = _resolve_correlation_id(request)
+        request_id = correlation_id
+        debug_ctx = debug_context_factory(request) if debug_context_factory else None
+        if debug_ctx:
+            request.state.debug_ctx = debug_ctx
+        token = getattr(getattr(request, "state", object()), "debug_ctx_token", None) if debug_ctx else None
+        try:
+            if provider == "oidc" and oidc_adapter:
+                code = body.get("code")
+                if not code:
+                    raise HTTPException(status_code=400, detail="کد اعتبارسنجی الزامی است.")
+                session = await oidc_adapter.authenticate(
+                    code=code,
+                    correlation_id=correlation_id,
+                    request_id=request_id,
+                    debug=debug_ctx,
+                )
+            elif provider == "saml" and saml_adapter:
+                assertion = body.get("assertion")
+                if not assertion:
+                    raise HTTPException(status_code=400, detail="پیام هویتی الزامی است.")
+                session = await saml_adapter.authenticate(
+                    assertion=assertion,
+                    correlation_id=correlation_id,
+                    request_id=request_id,
+                )
+            else:
+                raise HTTPException(status_code=400, detail="ارائه‌دهنده نامعتبر است.")
+        except AuthError as exc:
+            status = 403 if exc.code == "AUTH_FORBIDDEN" else 502 if exc.code == "AUTH_IDP_ERROR" else 400
+            raise HTTPException(status_code=status, detail=exc.message_fa) from exc
+        finally:
+            if token is not None:
+                reset_debug_context(token)
+                setattr(request.state, "debug_ctx_token", None)
+        response = JSONResponse({"status": "ok", "role": session.role, "center_scope": session.center_scope})
+        order = getattr(request.state, "middleware_order", [])
+        if order:
+            response.headers["X-Middleware-Order"] = ",".join(order)
+        response.set_cookie(
+            "bridge_session",
+            value=session.sid,
+            max_age=config.session_ttl_seconds,
+            httponly=True,
+            samesite="lax",
+            secure=os.getenv("ENVIRONMENT") == "production",
+        )
+        return response
+
+    @app.post("/auth/logout")
+    async def logout(request: Request) -> JSONResponse:
+        sid = request.cookies.get("bridge_session")
+        if sid:
+            await session_store.delete(sid)
+        response = JSONResponse({"status": "ok"})
+        order = getattr(request.state, "middleware_order", [])
+        if order:
+            response.headers["X-Middleware-Order"] = ",".join(order)
+        response.delete_cookie("bridge_session")
+        return response
+
+    @app.get("/metrics")
+    async def metrics_endpoint(request: Request) -> PlainTextResponse:
+        token = request.headers.get("Authorization")
+        if token != f"Bearer {metrics_token}":
+            raise HTTPException(status_code=401, detail="توکن نامعتبر است.")
+        data = generate_latest(metrics.registry)
+        return PlainTextResponse(data.decode("utf-8"), media_type=CONTENT_TYPE_LATEST)
+
+    return app
+
+
+__all__ = ["create_sso_app"]

--- a/src/ui/templates/auth_dashboard.html
+++ b/src/ui/templates/auth_dashboard.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<div dir="rtl" class="auth-dashboard">
+  <h1>پنل دسترسی</h1>
+  <p>نقش جاری: <strong>{{ principal.role|default('نامشخص') }}</strong></p>
+  <p>اسکوپ مرکز: <strong>{{ principal.center_scope|default('همه') }}</strong></p>
+</div>
+{% endblock %}

--- a/src/ui/templates/base.html
+++ b/src/ui/templates/base.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <title>سامانه تخصیص</title>
+    <link rel="stylesheet" href="/static/css/app.css" />
+  </head>
+  <body>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/tests/audit/conftest.py
+++ b/tests/audit/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.auth.conftest"]

--- a/tests/audit/test_auth_audit.py
+++ b/tests/audit/test_auth_audit.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_audit_events_no_pii_and_tehran_clock(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+) -> None:
+    async def _run() -> None:
+        code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+        config = SSOConfig.from_env(oidc_provider.env())
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": code},
+                headers={"Idempotency-Key": "audit-ok", "X-RateLimit-Key": "demo"},
+            )
+            failure = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": "invalid"},
+                headers={"Idempotency-Key": "audit-fail", "X-RateLimit-Key": "demo"},
+            )
+        assert failure.status_code == 502
+        assert any(event["action"] == "AUTHN_FAIL" for event in audit_log.events)
+        for event in audit_log.events:
+            assert "AUTHN_" in event["action"]
+            assert event["ts"].endswith("+03:30")
+            assert len(event.get("cid", "")) == 24
+
+    asyncio.run(_run())

--- a/tests/auth/conftest.py
+++ b/tests/auth/conftest.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+
+from auth.metrics import AuthMetrics
+from auth.session_store import SessionStore
+from src.reliability.clock import Clock
+from tests.mock.oidc import MockOIDCProvider
+from tests.mock.saml import MockSAMLProvider
+
+
+def _extract_clock(source: Any) -> Any:
+    return getattr(source, "clock", source)
+
+
+@pytest.fixture(name="sso_clock")
+def sso_clock_fixture() -> SimpleNamespace:
+    holder = [datetime(2024, 3, 21, 9, 0, tzinfo=timezone.utc)]
+    tz = ZoneInfo("Asia/Tehran")
+
+    def now() -> datetime:
+        return holder[0]
+
+    clock = Clock(timezone=tz, _now_factory=now)
+
+    def advance(seconds: int) -> None:
+        holder[0] = holder[0] + timedelta(seconds=seconds)
+
+    def set_time(value: datetime) -> None:
+        holder[0] = value
+
+    return SimpleNamespace(clock=clock, advance=advance, set=set_time)
+
+
+@pytest.fixture
+def session_store(sso_clock: SimpleNamespace):
+    from src.fakeredis import FakeStrictRedis
+
+    redis = FakeStrictRedis()
+    store = SessionStore(redis, ttl_seconds=900, clock=_extract_clock(sso_clock), namespace=f"sso:{id(redis)}")
+    try:
+        yield store
+    finally:
+        redis.flushdb()
+
+
+@pytest.fixture
+def auth_metrics():
+    metrics = AuthMetrics.build()
+    yield metrics
+
+
+@pytest.fixture
+def audit_log():
+    events: list[dict[str, Any]] = []
+
+    async def sink(action: str, correlation_id: str, payload: dict[str, Any]) -> None:
+        events.append({"action": action, "correlation_id": correlation_id, **payload})
+
+    yield SimpleNamespace(events=events, sink=sink)
+
+
+@pytest.fixture
+def oidc_provider(sso_clock: SimpleNamespace):
+    provider = MockOIDCProvider(clock=_extract_clock(sso_clock))
+    yield provider
+
+
+@pytest.fixture
+def oidc_http_client(oidc_provider: MockOIDCProvider):
+    client = httpx.AsyncClient(transport=oidc_provider.transport, base_url=oidc_provider.issuer)
+    try:
+        yield client
+    finally:
+        asyncio.run(client.aclose())
+
+
+@pytest.fixture
+def saml_provider(sso_clock: SimpleNamespace):
+    provider = MockSAMLProvider(clock=_extract_clock(sso_clock))
+    yield provider

--- a/tests/auth/test_jwks_rotation_retry.py
+++ b/tests/auth/test_jwks_rotation_retry.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from auth.errors import ProviderError
+from auth.metrics import AuthMetrics
+from auth.oidc_adapter import OIDCAdapter
+from auth.session_store import SessionStore
+from auth.utils import exponential_backoff
+from config.env_schema import SSOConfig
+from src.fakeredis import FakeStrictRedis
+
+pytest_plugins = ["tests.fixtures.debug_context"]
+
+
+def test_kid_rotation_success_then_exhaustion_metrics(
+    oidc_provider,
+    oidc_http_client,
+    sso_clock,
+    audit_log,
+) -> None:
+    async def _run() -> None:
+        config = SSOConfig.from_env(oidc_provider.env())
+        # Scenario 1: rotation succeeds after JWKS refresh
+        metrics_success = AuthMetrics.build()
+        sleep_success: list[float] = []
+
+        async def sleep_record_success(delay: float) -> None:
+            sleep_success.append(delay)
+
+        redis_success = FakeStrictRedis()
+        store_success = SessionStore(
+            redis_success,
+            ttl_seconds=config.session_ttl_seconds,
+            clock=sso_clock.clock,
+            namespace=f"sso-success-{uuid4().hex}",
+        )
+        adapter_success = OIDCAdapter(
+            settings=config.oidc,
+            http_client=oidc_http_client,
+            session_store=store_success,
+            metrics=metrics_success,
+            clock=sso_clock.clock,
+            audit_sink=audit_log.sink,
+            ldap_mapper=None,
+            max_retries=3,
+            backoff_seconds=0.05,
+            sleep=sleep_record_success,
+        )
+        oidc_provider.rotate_signing_key("rotated", "rotated-secret", publish=False)
+        oidc_provider.queue_jwks(
+            [
+                [{"kty": "oct", "kid": "mock-key", "k": oidc_provider.client_secret}],
+                [{"kty": "oct", "kid": "rotated", "k": "rotated-secret"}],
+            ]
+        )
+        code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+        session = await adapter_success.authenticate(
+            code=code,
+            correlation_id="rid-success",
+            request_id="rid-success",
+        )
+        assert session.role == "ADMIN"
+        assert metrics_success.retry_attempts_total.labels(adapter="oidc", reason="jwks")._value.get() == 1.0
+        assert (
+            metrics_success.retry_exhaustion_total.labels(adapter="oidc", reason="jwks")._value.get() == 0.0
+        )
+        expected_delay = exponential_backoff(0.05, 1, jitter_seed="rid-success:jwks")
+        assert pytest.approx(sleep_success, rel=1e-6) == [expected_delay]
+        redis_success.flushdb()
+
+        # Scenario 2: repeated mismatch -> exhaustion metrics
+        metrics_fail = AuthMetrics.build()
+        sleep_fail: list[float] = []
+
+        async def sleep_record_fail(delay: float) -> None:
+            sleep_fail.append(delay)
+
+        redis_fail = FakeStrictRedis()
+        store_fail = SessionStore(
+            redis_fail,
+            ttl_seconds=config.session_ttl_seconds,
+            clock=sso_clock.clock,
+            namespace=f"sso-fail-{uuid4().hex}",
+        )
+        adapter_fail = OIDCAdapter(
+            settings=config.oidc,
+            http_client=oidc_http_client,
+            session_store=store_fail,
+            metrics=metrics_fail,
+            clock=sso_clock.clock,
+            audit_sink=audit_log.sink,
+            ldap_mapper=None,
+            max_retries=3,
+            backoff_seconds=0.05,
+            sleep=sleep_record_fail,
+        )
+        oidc_provider.rotate_signing_key("exhaust", "exhaust-secret", publish=False)
+        oidc_provider.queue_jwks(
+            [
+                [{"kty": "oct", "kid": "stale", "k": "legacy-secret"}],
+                [{"kty": "oct", "kid": "stale", "k": "legacy-secret"}],
+                [{"kty": "oct", "kid": "stale", "k": "legacy-secret"}],
+            ]
+        )
+        code_fail = oidc_provider.issue_code({"role": "MANAGER", "center_scope": "123"})
+        with pytest.raises(ProviderError) as excinfo:
+            await adapter_fail.authenticate(
+                code=code_fail,
+                correlation_id="rid-fail",
+                request_id="rid-fail",
+            )
+        assert excinfo.value.code == "AUTH_JWKS_EXHAUSTED"
+        attempts = metrics_fail.retry_attempts_total.labels(adapter="oidc", reason="jwks")._value.get()
+        exhaustion = metrics_fail.retry_exhaustion_total.labels(adapter="oidc", reason="jwks")._value.get()
+        assert attempts == 2.0
+        assert exhaustion == 1.0
+        expected_fail = [
+            exponential_backoff(0.05, 1, jitter_seed="rid-fail:jwks"),
+            exponential_backoff(0.05, 2, jitter_seed="rid-fail:jwks"),
+        ]
+        assert pytest.approx(sleep_fail, rel=1e-6) == expected_fail
+        registry = metrics_fail.registry
+        sum_value = registry.get_sample_value(
+            "auth_retry_backoff_seconds_sum",
+            {"adapter": "oidc", "reason": "jwks"},
+        )
+        count_value = registry.get_sample_value(
+            "auth_retry_backoff_seconds_count",
+            {"adapter": "oidc", "reason": "jwks"},
+        )
+        assert pytest.approx(sum_value, rel=1e-6) == sum(expected_fail)
+        assert count_value == 2.0
+        redis_fail.flushdb()
+
+    asyncio.run(_run())

--- a/tests/auth/test_ldap_mapper.py
+++ b/tests/auth/test_ldap_mapper.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+
+from auth.ldap_adapter import LdapGroupMapper, LdapSettings
+from tests.mock.fake_ldap import FakeLDAPDirectory
+
+
+def test_ldap_group_to_role_center() -> None:
+    directory = FakeLDAPDirectory({"user": ["MANAGER:۰۰۱۲"]})
+    mapper = LdapGroupMapper(directory.fetch_groups, settings=LdapSettings(group_rules={}))
+
+    async def _run() -> tuple[str, str]:
+        return await mapper({"sub": "user"})
+
+    role, scope = asyncio.run(_run())
+    assert role == "MANAGER"
+    assert scope == "0012"
+
+
+def test_ldap_group_rules_override() -> None:
+    directory = FakeLDAPDirectory({"user": ["ignored"]})
+    settings = LdapSettings(group_rules={"ignored": ("ADMIN", "ALL")})
+    mapper = LdapGroupMapper(directory.fetch_groups, settings=settings)
+
+    async def _run() -> tuple[str, str]:
+        return await mapper({"sub": "user"})
+
+    role, scope = asyncio.run(_run())
+    assert role == "ADMIN"
+    assert scope == "ALL"

--- a/tests/auth/test_ldap_timeout_retry.py
+++ b/tests/auth/test_ldap_timeout_retry.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from auth.errors import ProviderError
+from auth.ldap_adapter import LdapGroupMapper, LdapSettings
+from auth.metrics import AuthMetrics
+from auth.utils import exponential_backoff
+
+pytest_plugins = ["tests.fixtures.debug_context"]
+
+
+def test_retry_then_success_and_exhaustion_metrics() -> None:
+    async def _run() -> None:
+        metrics_success = AuthMetrics.build()
+        sleep_success: list[float] = []
+        attempts = {"count": 0}
+
+        async def fetch_success(user: str):
+            attempts["count"] += 1
+            if attempts["count"] <= 2:
+                raise asyncio.TimeoutError
+            return ["MANAGER:456"]
+
+        async def sleep_record(delay: float) -> None:
+            sleep_success.append(delay)
+
+        mapper_success = LdapGroupMapper(
+            fetch_success,
+            settings=LdapSettings(timeout_seconds=0.1),
+            metrics=metrics_success,
+            max_retries=4,
+            backoff_seconds=0.05,
+            sleep=sleep_record,
+        )
+        role, scope = await mapper_success({"sub": "user-ldap"}, correlation_id="rid-ldap")
+        assert role == "MANAGER"
+        assert scope == "456"
+        attempts_value = metrics_success.retry_attempts_total.labels(adapter="ldap", reason="timeout")._value.get()
+        exhaustion_value = metrics_success.retry_exhaustion_total.labels(adapter="ldap", reason="timeout")._value.get()
+        assert attempts_value == 2.0
+        assert exhaustion_value == 0.0
+        expected_delays = [
+            exponential_backoff(0.05, 1, jitter_seed="rid-ldap:timeout"),
+            exponential_backoff(0.05, 2, jitter_seed="rid-ldap:timeout"),
+        ]
+        assert pytest.approx(sleep_success, rel=1e-6) == expected_delays
+        registry_success = metrics_success.registry
+        sum_success = registry_success.get_sample_value(
+            "auth_retry_backoff_seconds_sum",
+            {"adapter": "ldap", "reason": "timeout"},
+        )
+        count_success = registry_success.get_sample_value(
+            "auth_retry_backoff_seconds_count",
+            {"adapter": "ldap", "reason": "timeout"},
+        )
+        assert pytest.approx(sum_success, rel=1e-6) == sum(expected_delays)
+        assert count_success == 2.0
+
+        metrics_fail = AuthMetrics.build()
+        sleep_fail: list[float] = []
+
+        async def fetch_fail(user: str):
+            raise asyncio.TimeoutError
+
+        async def sleep_record_fail(delay: float) -> None:
+            sleep_fail.append(delay)
+
+        mapper_fail = LdapGroupMapper(
+            fetch_fail,
+            settings=LdapSettings(timeout_seconds=0.1),
+            metrics=metrics_fail,
+            max_retries=3,
+            backoff_seconds=0.05,
+            sleep=sleep_record_fail,
+        )
+        with pytest.raises(ProviderError) as excinfo:
+            await mapper_fail({"sub": "user-fail"}, correlation_id="rid-fail")
+        assert excinfo.value.code == "AUTH_LDAP_TIMEOUT"
+        attempts_fail = metrics_fail.retry_attempts_total.labels(adapter="ldap", reason="timeout")._value.get()
+        exhaustion_fail = metrics_fail.retry_exhaustion_total.labels(adapter="ldap", reason="timeout")._value.get()
+        assert attempts_fail == 2.0
+        assert exhaustion_fail == 1.0
+        expected_fail = [
+            exponential_backoff(0.05, 1, jitter_seed="rid-fail:timeout"),
+            exponential_backoff(0.05, 2, jitter_seed="rid-fail:timeout"),
+        ]
+        assert pytest.approx(sleep_fail, rel=1e-6) == expected_fail
+        registry_fail = metrics_fail.registry
+        sum_fail = registry_fail.get_sample_value(
+            "auth_retry_backoff_seconds_sum",
+            {"adapter": "ldap", "reason": "timeout"},
+        )
+        count_fail = registry_fail.get_sample_value(
+            "auth_retry_backoff_seconds_count",
+            {"adapter": "ldap", "reason": "timeout"},
+        )
+        assert pytest.approx(sum_fail, rel=1e-6) == sum(expected_fail)
+        assert count_fail == 2.0
+
+    asyncio.run(_run())

--- a/tests/auth/test_oidc_flow.py
+++ b/tests/auth/test_oidc_flow.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_oidc_ok_maps_to_admin_all(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+        config = SSOConfig.from_env(oidc_provider.env())
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": code},
+                headers={"Idempotency-Key": "demo-key", "X-RateLimit-Key": "demo"},
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"status": "ok", "role": "ADMIN", "center_scope": "ALL"}
+        assert "RateLimit" in response.headers["X-Middleware-Order"]
+        sid = response.cookies.get("bridge_session")
+        session = await session_store.get(sid)
+        assert session is not None
+        assert session.role == "ADMIN"
+        assert session.center_scope == "ALL"
+        assert audit_log.events[-1]["action"] == "AUTHN_OK"
+        metrics = auth_metrics.ok_total.labels(provider="oidc")._value.get()
+        assert metrics == 1.0
+
+    asyncio.run(_run())

--- a/tests/auth/test_oversized_saml_assertion.py
+++ b/tests/auth/test_oversized_saml_assertion.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from auth.errors import ProviderError
+from auth.saml_adapter import SAMLAdapter
+from config.env_schema import SSOConfig
+
+
+def test_oversized_saml_assertion(
+    saml_provider,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        config = SSOConfig.from_env(saml_provider.env())
+        adapter = SAMLAdapter(
+            settings=config.saml,
+            session_store=session_store,
+            metrics=auth_metrics,
+            clock=sso_clock.clock,
+            audit_sink=audit_log.sink,
+            ldap_mapper=None,
+        )
+        oversized = "<Assertion>" + "A" * (250 * 1024 + 1) + "</Assertion>"
+        with pytest.raises(ProviderError) as exc:
+            await adapter.authenticate(assertion=oversized, correlation_id="cid", request_id="rid")
+        assert "بسیار بزرگ" in exc.value.message_fa
+
+    asyncio.run(_run())

--- a/tests/auth/test_saml_flow.py
+++ b/tests/auth/test_saml_flow.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_saml_ok_maps_manager_center(
+    saml_provider,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        assertion = saml_provider.build_assertion(role="MANAGER", center_scope="۰۱۲۳")
+        config = SSOConfig.from_env(saml_provider.env())
+        transport = httpx.MockTransport(lambda request: httpx.Response(404))
+        async with httpx.AsyncClient(transport=transport, base_url="https://unused.local") as http_client:
+            app = create_sso_app(
+                config=config,
+                clock=sso_clock.clock,
+                session_store=session_store,
+                metrics=auth_metrics,
+                audit_sink=audit_log.sink,
+                http_client=http_client,
+                ldap_mapper=None,
+                metrics_token="metrics-token",
+            )
+            transport_app = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport_app, base_url="http://testserver") as client:
+                response = await client.post(
+                    "/auth/callback",
+                    json={"provider": "saml", "assertion": assertion},
+                    headers={"Idempotency-Key": "saml-key", "X-RateLimit-Key": "demo"},
+                )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == {"status": "ok", "role": "MANAGER", "center_scope": "0123"}
+        sid = response.cookies.get("bridge_session")
+        session = await session_store.get(sid)
+        assert session.center_scope == "0123"
+        assert audit_log.events[-1]["action"] == "AUTHN_OK"
+        saml_metric = auth_metrics.ok_total.labels(provider="saml")._value.get()
+        assert saml_metric == 1.0
+
+    asyncio.run(_run())

--- a/tests/auth/test_session_ttl.py
+++ b/tests/auth/test_session_ttl.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import asyncio
+
+
+def test_session_ttl(session_store):
+    async def _run():
+        session = await session_store.create(
+            correlation_id="rid",
+            subject="user",
+            role="ADMIN",
+            center_scope="ALL",
+        )
+        assert session.ttl_seconds == 900
+        assert (session.expires_at - session.issued_at).total_seconds() == 900
+
+    asyncio.run(_run())

--- a/tests/blue_green/conftest.py
+++ b/tests/blue_green/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.auth.conftest"]

--- a/tests/blue_green/test_sso_toggle.py
+++ b/tests/blue_green/test_sso_toggle.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_sessions_survive_toggle(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        env = oidc_provider.env()
+        env["SSO_BLUE_GREEN_STATE"] = "warming"
+        config = SSOConfig.from_env(env)
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            warm_code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+            warm = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": warm_code},
+                headers={"Idempotency-Key": "warm", "X-RateLimit-Key": "demo"},
+            )
+            assert warm.status_code == 503
+            config.blue_green_state = "green"
+            ready_code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+            ready = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": ready_code},
+                headers={"Idempotency-Key": "ready", "X-RateLimit-Key": "demo"},
+            )
+            assert ready.status_code == 200
+            sid = ready.cookies.get("bridge_session")
+            config.blue_green_state = "blue"
+            blocked_code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+            blocked = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": blocked_code},
+                headers={"Idempotency-Key": "blocked", "X-RateLimit-Key": "demo"},
+            )
+            assert blocked.status_code == 503
+        session = await session_store.get(sid)
+        assert session is not None
+
+    asyncio.run(_run())

--- a/tests/blue_green/test_zero_downtime.py
+++ b/tests/blue_green/test_zero_downtime.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_zero_downtime(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        env = oidc_provider.env()
+        env["SSO_BLUE_GREEN_STATE"] = "warming"
+        config = SSOConfig.from_env(env)
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            login = await client.get("/auth/login")
+            assert login.status_code == 200
+            config.blue_green_state = "green"
+            code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+            ready = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": code},
+                headers={"Idempotency-Key": "zero", "X-RateLimit-Key": "demo"},
+            )
+            assert ready.status_code == 200
+
+    asyncio.run(_run())

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.auth.conftest"]

--- a/tests/compat/test_existing_rbac.py
+++ b/tests/compat/test_existing_rbac.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from src.phase6_import_to_sabt.security.rbac import AuthenticatedActor
+
+
+def test_existing_rbac():
+    actor = AuthenticatedActor(token_fingerprint="abc", role="ADMIN", center_scope=None, metrics_only=False)
+    assert actor.can_access_center(101)

--- a/tests/compat/test_logging_policy.py
+++ b/tests/compat/test_logging_policy.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_logging_policy(caplog, oidc_provider, oidc_http_client, session_store, auth_metrics, sso_clock, audit_log):
+    async def _run() -> None:
+        code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+        config = SSOConfig.from_env(oidc_provider.env())
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            with caplog.at_level(logging.INFO):
+                await client.post(
+                    "/auth/callback",
+                    json={"provider": "oidc", "code": code},
+                    headers={
+                        "Idempotency-Key": "log",
+                        "X-RateLimit-Key": "demo",
+                        "X-Request-ID": "RID1234567890",
+                    },
+                )
+        records = [record for record in caplog.records if record.getMessage() == "OIDC_AUTH_OK"]
+        assert records
+        assert len(records[0].cid) == 8
+
+    asyncio.run(_run())

--- a/tests/compat/test_metrics_guard.py
+++ b/tests/compat/test_metrics_guard.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_metrics_guard(oidc_provider, oidc_http_client, session_store, auth_metrics, sso_clock, audit_log):
+    async def _run() -> None:
+        config = SSOConfig.from_env(oidc_provider.env())
+        token = "metrics-token"
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token=token,
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            unauthorized = await client.get("/metrics")
+            assert unauthorized.status_code == 401
+            authorized = await client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
+        assert authorized.status_code == 200
+
+    asyncio.run(_run())

--- a/tests/compat/test_signed_urls_unchanged.py
+++ b/tests/compat/test_signed_urls_unchanged.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from src.phase6_import_to_sabt.security import enforce_center_scope, AuthenticatedActor
+
+
+def test_signed_urls_unchanged():
+    actor = AuthenticatedActor(token_fingerprint="x", role="ADMIN", center_scope=None, metrics_only=False)
+    enforce_center_scope(actor, center=42)

--- a/tests/config/test_env_schema.py
+++ b/tests/config/test_env_schema.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from config.env_schema import SSOConfig
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "SSO_ENABLED": "true",
+        "SSO_SESSION_TTL_SECONDS": "900",
+        "SSO_BLUE_GREEN_STATE": "green",
+        "OIDC_CLIENT_ID": "client",
+        "OIDC_CLIENT_SECRET": "secret",
+        "OIDC_ISSUER": "https://issuer",
+        "OIDC_SCOPES": "openid",
+    }
+
+
+def test_unknown_key():
+    env = _base_env()
+    env["UNKNOWN"] = "value"
+    with pytest.raises(ValueError) as exc:
+        SSOConfig.from_env(env)
+    assert "کلید ناشناخته" in str(exc.value)
+
+
+def test_missing_required():
+    env = _base_env()
+    env.pop("OIDC_CLIENT_ID")
+    with pytest.raises(ValueError) as exc:
+        SSOConfig.from_env(env)
+    assert "کلید الزامی" in str(exc.value)
+
+
+def test_type_validation():
+    env = _base_env()
+    env["SSO_SESSION_TTL_SECONDS"] = "invalid"
+    with pytest.raises(ValueError) as exc:
+        SSOConfig.from_env(env)
+    assert "نوع مقدار" in str(exc.value)

--- a/tests/debug/test_debug_context_default_factory_integration.py
+++ b/tests/debug/test_debug_context_default_factory_integration.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from src.app.bootstrap_logging import bootstrap_logging
+from src.app.context import set_debug_context
+from src.debug.debug_context import DebugContextFactory
+from src.fakeredis import FakeStrictRedis
+from src.logging.json_logger import LogEnricher
+
+
+@pytest.fixture
+def redis_client() -> FakeStrictRedis:
+    client = FakeStrictRedis()
+    client.flushdb()
+    try:
+        yield client
+    finally:
+        client.flushdb()
+
+
+def _build_request(rid: str) -> SimpleNamespace:
+    def endpoint() -> None:  # pragma: no cover - used for metadata only
+        return None
+
+    scope = {"path": "/auth/callback", "endpoint": endpoint}
+    return SimpleNamespace(
+        headers={"X-Request-ID": rid},
+        scope=scope,
+        state=SimpleNamespace(),
+        app=SimpleNamespace(title="sso"),
+    )
+
+
+def test_auto_enriches_and_masks(redis_client: FakeStrictRedis, monkeypatch: pytest.MonkeyPatch) -> None:
+    root_logger = logging.getLogger()
+    initial_filters = list(root_logger.filters)
+    monkeypatch.setenv("DEBUG_CONTEXT_ENABLE", "true")
+    bootstrap_logging()
+    handler_stream = io.StringIO()
+    handler = logging.StreamHandler(handler_stream)
+    handler.setFormatter(logging.Formatter("%(message)s|%(debug_context)s"))
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+    redis_key = f"sso_session:{uuid.uuid4().hex}"
+    redis_client.set(redis_key, "token")
+    audit_events = [
+        {
+            "id": 1,
+            "action": "AUTHN_FAIL",
+            "correlation_id": "email@example.com",
+            "ts": "2024-03-21T09:00:00+00:00",
+        }
+    ]
+    factory = DebugContextFactory(
+        redis=redis_client,
+        audit_fetcher=lambda: list(audit_events),
+        namespace="tests.debug",
+    )
+    request = _build_request("rid-test")
+    try:
+        ctx = factory(request)
+        root_logger.info("PHASE10_DEBUG", extra={"rid": ctx.rid})
+        captured = handler_stream.getvalue()
+        assert captured.strip(), "Missing log output"
+        assert redis_key in captured, f"Redis key not found. Context: {captured}"
+        assert "email@example.com" not in captured, f"PII leaked. Context: {captured}"
+        payload = captured.split("|", 1)[1].strip()
+        snapshot = json.loads(payload)
+        assert snapshot["rid"] == "rid-test", f"Unexpected rid. Snapshot: {snapshot}"
+        assert snapshot["namespace"] == "tests.debug", f"Unexpected namespace. Snapshot: {snapshot}"
+        assert snapshot["audit_events"][0]["cid"] != "email@example.com", f"CID leaked. Snapshot: {snapshot}"
+        set_debug_context(None)
+        handler_stream.truncate(0)
+        handler_stream.seek(0)
+        root_logger.info("PHASE10_NOCTX")
+        fallback = handler_stream.getvalue().strip().split("|")[-1]
+        assert fallback == "{}", f"Fallback context invalid. Context: {fallback}"
+    finally:
+        root_logger.removeHandler(handler)
+        handler.close()
+        set_debug_context(None)
+        for filt in list(root_logger.filters):
+            if isinstance(filt, LogEnricher) and filt not in initial_filters:
+                root_logger.removeFilter(filt)
+        for existing_handler in list(root_logger.handlers):
+            for filt in list(existing_handler.filters):
+                if isinstance(filt, LogEnricher):
+                    existing_handler.removeFilter(filt)

--- a/tests/debug/test_debug_context_fixture.py
+++ b/tests/debug/test_debug_context_fixture.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest_plugins = ["tests.fixtures.debug_context", "pytester"]
+
+
+def test_snapshot_includes_expected_fields(debug_ctx) -> None:
+    ctx = debug_ctx.ctx
+    redis = debug_ctx.redis
+    audit = debug_ctx.audit
+
+    redis.set("sso_session:test", "value")
+    redis.set("idem:abc", "value")
+    redis.set("ratelimit:xyz", "value")
+    audit.append({"action": "AUTHN_OK", "correlation_id": "user@example.com", "ts": "2024-03-21T09:00:00+00:00"})
+    ctx.record_http_attempt(method="post", url="https://idp/token", status=500, duration=0.123456)
+    ctx.set_last_error(code="AUTH_FAIL", message="email@example.com should not leak")
+
+    snapshot = ctx.snapshot()
+    payload = json.dumps(snapshot, ensure_ascii=False)
+    assert "sso_session:test" in snapshot["redis_keys"]
+    assert snapshot["audit_events"][-1]["cid"] != "user@example.com"
+    assert "email@example.com" not in payload
+    assert snapshot["http_attempts"][0]["status"] == 500
+    assert snapshot["http_attempts"][0]["method"] == "POST"
+    assert snapshot["last_error"]["code"] == "AUTH_FAIL"
+    assert snapshot["last_error"]["message"] != "email@example.com should not leak"
+
+
+def test_attaches_and_masks_no_pii(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile(
+        """
+        pytest_plugins = ["tests.fixtures.debug_context"]
+
+        def test_failure(debug_ctx):
+            ctx = debug_ctx.ctx
+            ctx.set_last_error(code="AUTH_FAIL", message="email@example.com")
+            assert False
+        """
+    )
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(failed=1)
+    output = result.stdout.str()
+    assert "DebugContext:" in output
+    context_fragment = output.split("DebugContext:", 1)[1]
+    assert "email@example.com" not in context_fragment

--- a/tests/docs/test_runbook_metrics_section.py
+++ b/tests/docs/test_runbook_metrics_section.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_metrics_names_present() -> None:
+    content = Path("RUNBOOK.md").read_text(encoding="utf-8")
+    assert "auth_retry_exhaustion_total" in content, f"Metric missing. Context: {content}"
+    assert "auth_retry_backoff_seconds" in content, f"Histogram missing. Context: {content}"
+    assert "DebugContext" in content, f"Debug guidance missing. Context: {content}"

--- a/tests/fixtures/debug_context.py
+++ b/tests/fixtures/debug_context.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+import pytest
+
+from src.debug.debug_context import DebugContext
+from src.fakeredis import FakeStrictRedis
+
+
+@pytest.fixture
+def debug_ctx(request):
+    redis = FakeStrictRedis()
+    audit_events: list[dict[str, Any]] = []
+
+    def scan(pattern: str) -> Iterable[str]:
+        return redis.scan_iter(match=pattern)
+
+    context = DebugContext(
+        rid=request.node.name,
+        operation=request.function.__name__ if getattr(request, "function", None) else request.node.name,
+        namespace=request.module.__name__,
+        redis_scan=scan,
+        audit_events=lambda: list(audit_events),
+    )
+
+    request.node.debug_ctx = context
+
+    container = SimpleNamespace(ctx=context, redis=redis, audit=audit_events)
+    try:
+        yield container
+    finally:
+        redis.flushdb()
+        container.audit.clear()
+        context.http_attempts.clear()
+        context.last_error = None
+
+
+def pytest_runtest_makereport(item, call):  # pragma: no cover - pytest hook
+    if call.when != "call" or call.excinfo is None:
+        return
+    context: DebugContext | None = getattr(item, "debug_ctx", None)
+    if not context:
+        return
+    try:
+        payload = context.snapshot()
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    except Exception as exc:  # noqa: BLE001 - best effort reporting
+        serialized = f"<debug-context-error:{exc}>"
+    original = call.excinfo.value.args
+    call.excinfo.value.args = (*original, f"\nDebugContext: {serialized}")

--- a/tests/mock/fake_ldap.py
+++ b/tests/mock/fake_ldap.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+
+class FakeLDAPDirectory:
+    def __init__(self, mapping: Dict[str, Iterable[str]]) -> None:
+        self._mapping = {key: list(value) for key, value in mapping.items()}
+
+    async def fetch_groups(self, user: str) -> List[str]:
+        return list(self._mapping.get(user, []))
+
+
+__all__ = ["FakeLDAPDirectory"]

--- a/tests/mock/oidc.py
+++ b/tests/mock/oidc.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import secrets
+from collections import deque
+from datetime import timedelta
+from typing import Any, Deque, Mapping
+from uuid import uuid4
+from urllib.parse import parse_qs
+
+import httpx
+
+from auth.utils import encode_base64url
+
+
+class MockOIDCProvider:
+    def __init__(self, *, clock) -> None:
+        self.clock = clock
+        self.issuer = "https://mock-oidc.local"
+        self.client_id = "mock-client"
+        self.client_secret = "mock-secret"
+        self.scopes = ("openid", "profile")
+        self.token_endpoint = f"{self.issuer}/token"
+        self.jwks_endpoint = f"{self.issuer}/jwks"
+        self.auth_endpoint = f"{self.issuer}/authorize"
+        self.transport = httpx.MockTransport(self._handle)
+        self._codes: dict[str, Mapping[str, Any]] = {}
+        self._key = {"kty": "oct", "kid": "mock-key", "k": self.client_secret}
+        self._signing_secret = self.client_secret
+        self._jwks_current: list[Mapping[str, Any]] = [self._key]
+        self._jwks_queue: Deque[list[Mapping[str, Any]]] = deque()
+
+    def issue_code(self, claims: Mapping[str, Any], *, code: str | None = None) -> str:
+        issued = {"sub": claims.get("sub", uuid4().hex)}
+        issued.update(claims)
+        key = code or secrets.token_hex(8)
+        self._codes[key] = issued
+        return key
+
+    def env(self) -> dict[str, str]:
+        return {
+            "SSO_ENABLED": "true",
+            "SSO_SESSION_TTL_SECONDS": "900",
+            "SSO_BLUE_GREEN_STATE": "green",
+            "OIDC_CLIENT_ID": self.client_id,
+            "OIDC_CLIENT_SECRET": self.client_secret,
+            "OIDC_ISSUER": self.issuer,
+            "OIDC_SCOPES": "openid profile",
+            "OIDC_TOKEN_ENDPOINT": self.token_endpoint,
+            "OIDC_AUTH_ENDPOINT": self.auth_endpoint,
+            "OIDC_JWKS_ENDPOINT": self.jwks_endpoint,
+        }
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/token"):
+            form = parse_qs(request.content.decode())
+            code = form.get("code", [None])[0]
+            if not code or code not in self._codes:
+                return httpx.Response(400, json={"error": "invalid_grant"})
+            claims = self._codes.pop(code)
+            id_token = self._build_token(claims)
+            return httpx.Response(200, json={"id_token": id_token})
+        if request.url.path.endswith("/jwks"):
+            if self._jwks_queue:
+                self._jwks_current = self._jwks_queue.popleft()
+            return httpx.Response(200, json={"keys": list(self._jwks_current)})
+        if request.url.path.endswith("/authorize"):
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404, json={"error": "not_found"})
+
+    def _build_token(self, claims: Mapping[str, Any]) -> str:
+        header = {"alg": "HS256", "kid": self._key["kid"]}
+        now = self.clock.now()
+        payload = {
+            "iss": self.issuer,
+            "aud": self.client_id,
+            "exp": (now + timedelta(minutes=5)).timestamp(),
+            "nbf": (now - timedelta(minutes=1)).timestamp(),
+            "sub": claims.get("sub"),
+            "role": claims.get("role"),
+            "center_scope": claims.get("center_scope"),
+        }
+        if "userinfo" in claims:
+            payload["userinfo"] = claims["userinfo"]
+        header_segment = encode_base64url(json.dumps(header).encode())
+        payload_segment = encode_base64url(json.dumps(payload).encode())
+        signing_input = f"{header_segment}.{payload_segment}".encode()
+        signature = self._sign(signing_input)
+        signature_segment = encode_base64url(signature)
+        return f"{header_segment}.{payload_segment}.{signature_segment}"
+
+    def _sign(self, payload: bytes) -> bytes:
+        import hmac
+        import hashlib
+
+        digest = hmac.new(self._signing_secret.encode(), payload, hashlib.sha256).digest()
+        return digest
+
+    def rotate_signing_key(self, kid: str, secret: str, *, publish: bool = False) -> None:
+        self._key = {"kty": "oct", "kid": kid, "k": secret}
+        self._signing_secret = secret
+        if publish:
+            self._jwks_current = [self._key]
+
+    def queue_jwks(self, payloads: list[list[Mapping[str, Any]]]) -> None:
+        self._jwks_queue = deque(payloads)
+
+    def publish_jwks(self, keys: list[Mapping[str, Any]]) -> None:
+        self._jwks_current = list(keys)
+
+
+__all__ = ["MockOIDCProvider"]

--- a/tests/mock/saml.py
+++ b/tests/mock/saml.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+
+class MockSAMLProvider:
+    def __init__(self, *, clock) -> None:
+        self.clock = clock
+        self.entity_id = "https://mock-saml.local/sp"
+        self.metadata_xml = "https://mock-saml.local/metadata"
+        self.certificate = "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+        self.key = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----"
+        self.audience = self.entity_id
+
+    def env(self) -> dict[str, str]:
+        return {
+            "SSO_ENABLED": "true",
+            "SSO_SESSION_TTL_SECONDS": "900",
+            "SSO_BLUE_GREEN_STATE": "green",
+            "SAML_SP_ENTITY_ID": self.entity_id,
+            "SAML_IDP_METADATA_XML": self.metadata_xml,
+            "SAML_SP_CERT_PEM": self.certificate,
+            "SAML_SP_KEY_PEM": self.key,
+            "SAML_AUDIENCE": self.audience,
+        }
+
+    def build_assertion(self, *, role: str, center_scope: str, name_id: str | None = None) -> str:
+        now = self.clock.now()
+        name_id = name_id or uuid4().hex
+        not_before = (now - timedelta(minutes=1)).isoformat()
+        not_on_or_after = (now + timedelta(minutes=5)).isoformat()
+        return f"""
+        <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+          <Issuer>mock-idp</Issuer>
+          <Subject>
+            <NameID>{name_id}</NameID>
+          </Subject>
+          <Conditions NotBefore="{not_before}" NotOnOrAfter="{not_on_or_after}">
+            <AudienceRestriction>
+              <Audience>{self.audience}</Audience>
+            </AudienceRestriction>
+          </Conditions>
+          <AttributeStatement>
+            <Attribute Name="role">
+              <AttributeValue>{role}</AttributeValue>
+            </Attribute>
+            <Attribute Name="center_scope">
+              <AttributeValue>{center_scope}</AttributeValue>
+            </Attribute>
+          </AttributeStatement>
+        </Assertion>
+        """.strip()
+
+
+__all__ = ["MockSAMLProvider"]

--- a/tests/mock/test_fake_ldap.py
+++ b/tests/mock/test_fake_ldap.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import asyncio
+
+from tests.mock.fake_ldap import FakeLDAPDirectory
+
+
+def test_fake_ldap_returns_groups():
+    directory = FakeLDAPDirectory({"alice": ["ADMIN:ALL", "extra"]})
+
+    async def _run():
+        return await directory.fetch_groups("alice")
+
+    groups = asyncio.run(_run())
+    assert groups == ["ADMIN:ALL", "extra"]

--- a/tests/mock/test_mock_oidc_idp.py
+++ b/tests/mock/test_mock_oidc_idp.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from src.reliability.clock import Clock
+from tests.mock.oidc import MockOIDCProvider
+
+
+def test_mock_oidc_idp_generates_signed_tokens():
+    async def _run() -> None:
+        clock = Clock(timezone=ZoneInfo("Asia/Tehran"), _now_factory=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc))
+        provider = MockOIDCProvider(clock=clock)
+        code = provider.issue_code({"role": "ADMIN", "center_scope": "ALL"}, code="abc")
+        async with httpx.AsyncClient(transport=provider.transport, base_url=provider.issuer) as client:
+            response = await client.post("/token", data={"code": code})
+            jwks = await client.get("/jwks")
+        assert response.status_code == 200
+        assert "id_token" in response.json()
+        assert jwks.json()["keys"][0]["kid"] == "mock-key"
+
+    asyncio.run(_run())

--- a/tests/mock/test_mock_saml_idp.py
+++ b/tests/mock/test_mock_saml_idp.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from src.reliability.clock import Clock
+from tests.mock.saml import MockSAMLProvider
+
+
+def test_mock_saml_idp_builds_assertion():
+    async def _run() -> str:
+        clock = Clock(timezone=ZoneInfo("Asia/Tehran"), _now_factory=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc))
+        provider = MockSAMLProvider(clock=clock)
+        return provider.build_assertion(role="ADMIN", center_scope="ALL", name_id="user")
+
+    assertion = asyncio.run(_run())
+    assert "<NameID>user</NameID>" in assertion
+    assert "Audience" in assertion

--- a/tests/mw/conftest.py
+++ b/tests/mw/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.auth.conftest"]

--- a/tests/mw/test_order_auth_callback.py
+++ b/tests/mw/test_order_auth_callback.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_middleware_order_post_callback(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+        config = SSOConfig.from_env(oidc_provider.env())
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": code},
+                headers={"Idempotency-Key": "order-key", "X-RateLimit-Key": "demo"},
+            )
+        assert response.status_code == 200
+        assert response.headers["X-Middleware-Order"] == "RateLimit,Idempotency,Auth"
+
+    asyncio.run(_run())

--- a/tests/obs/conftest.py
+++ b/tests/obs/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.auth.conftest"]

--- a/tests/obs/test_auth_metrics.py
+++ b/tests/obs/test_auth_metrics.py
@@ -1,40 +1,73 @@
 from __future__ import annotations
 
-from tests.phase6_import_to_sabt.access_helpers import access_test_app
+import asyncio
 
-TOKENS = [
-    {"value": "A" * 32, "role": "ADMIN"},
-    {"value": "B" * 32, "role": "MANAGER", "center": 909},
-]
+import httpx
+import pytest
 
-SIGNING_KEYS = [
-    {"kid": "KOBS", "secret": "S" * 48, "state": "active"},
-]
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
 
 
-def test_counters_increment(monkeypatch) -> None:
-    with access_test_app(monkeypatch, tokens=TOKENS, signing_keys=SIGNING_KEYS) as ctx:
-        denied = ctx.client.post(
-            "/api/jobs",
-            headers={
-                "Authorization": "Bearer bad-token",  # ensures failure path
-                "Idempotency-Key": "idem-metrics-fail",
-                "X-Client-ID": "metrics-client",
-            },
+def test_auth_metrics_emitted_and_token_guarded(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+) -> None:
+    async def _run() -> None:
+        code = oidc_provider.issue_code({"role": "ADMIN", "center_scope": "ALL"})
+        config = SSOConfig.from_env(oidc_provider.env())
+        token = "metrics-token"
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token=token,
         )
-        assert denied.status_code == 401
-
-        allowed = ctx.client.post(
-            "/api/jobs",
-            headers={
-                "Authorization": f"Bearer {TOKENS[0]['value']}",
-                "Idempotency-Key": "idem-metrics-ok",
-                "X-Client-ID": "metrics-client",
-            },
-        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": code},
+                headers={"Idempotency-Key": "metrics", "X-RateLimit-Key": "demo"},
+            )
+            denied = await client.get("/metrics")
+            assert denied.status_code == 401
+            allowed = await client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
         assert allowed.status_code == 200
+        assert "auth_ok_total" in allowed.text
 
-        fail_samples = ctx.metrics.auth_fail_total.collect()[0].samples
-        assert any(sample.labels["reason"] == "unknown_token" for sample in fail_samples)
-        ok_samples = ctx.metrics.auth_ok_total.collect()[0].samples
-        assert any(sample.labels["role"] == "ADMIN" for sample in ok_samples)
+    asyncio.run(_run())
+
+
+def test_retry_and_exhaustion_series_labels(auth_metrics) -> None:
+    auth_metrics.retry_attempts_total.labels(adapter="oidc", reason="jwks").inc()
+    auth_metrics.retry_attempts_total.labels(adapter="ldap", reason="timeout").inc(2)
+    auth_metrics.retry_exhaustion_total.labels(adapter="oidc", reason="jwks").inc()
+    auth_metrics.retry_backoff_seconds.labels(adapter="oidc", reason="jwks").observe(0.123)
+    auth_metrics.retry_backoff_seconds.labels(adapter="ldap", reason="timeout").observe(0.456)
+
+    registry = auth_metrics.registry
+    assert registry.get_sample_value(
+        "auth_retry_attempts_total",
+        {"adapter": "oidc", "reason": "jwks"},
+    ) == 1.0
+    assert registry.get_sample_value(
+        "auth_retry_attempts_total",
+        {"adapter": "ldap", "reason": "timeout"},
+    ) == 2.0
+    assert registry.get_sample_value(
+        "auth_retry_exhaustion_total",
+        {"adapter": "oidc", "reason": "jwks"},
+    ) == 1.0
+    assert registry.get_sample_value(
+        "auth_retry_backoff_seconds_sum",
+        {"adapter": "ldap", "reason": "timeout"},
+    ) == pytest.approx(0.456)

--- a/tests/risk/conftest.py
+++ b/tests/risk/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.auth.conftest"]

--- a/tests/risk/test_config_guard_rejection.py
+++ b/tests/risk/test_config_guard_rejection.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from config.env_schema import SSOConfig
+
+
+def test_config_guard_rejection_unknown_key():
+    env = {
+        "SSO_ENABLED": "true",
+        "SSO_SESSION_TTL_SECONDS": "900",
+        "SSO_BLUE_GREEN_STATE": "green",
+        "UNKNOWN_KEY": "x",
+    }
+    with pytest.raises(ValueError) as exc:
+        SSOConfig.from_env(env)
+    assert "کلید ناشناخته" in str(exc.value)

--- a/tests/risk/test_pii_validation.py
+++ b/tests/risk/test_pii_validation.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from config.env_schema import SSOConfig
+from src.security.sso_app import create_sso_app
+
+
+def test_pii_validation(
+    oidc_provider,
+    oidc_http_client,
+    session_store,
+    auth_metrics,
+    sso_clock,
+    audit_log,
+):
+    async def _run() -> None:
+        code = oidc_provider.issue_code(
+            {
+                "role": "ADMIN",
+                "center_scope": "ALL",
+                "userinfo": {"email": "user@example.com"},
+            }
+        )
+        config = SSOConfig.from_env(oidc_provider.env())
+        app = create_sso_app(
+            config=config,
+            clock=sso_clock.clock,
+            session_store=session_store,
+            metrics=auth_metrics,
+            audit_sink=audit_log.sink,
+            http_client=oidc_http_client,
+            ldap_mapper=None,
+            metrics_token="metrics-token",
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            await client.post(
+                "/auth/callback",
+                json={"provider": "oidc", "code": code},
+                headers={"Idempotency-Key": "pii", "X-RateLimit-Key": "demo"},
+            )
+        assert all("example.com" not in str(event) for event in audit_log.events)
+
+    asyncio.run(_run())

--- a/tests/runbook/test_runbook_content.py
+++ b/tests/runbook/test_runbook_content.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_runbook_content():
+    text = Path("RUNBOOK.md").read_text(encoding="utf-8")
+    assert "## sso-onboarding" in text
+    assert "Go/No-Go" in text
+    assert "blue" in text.lower()

--- a/tests/ui/test_role_display_rtl.py
+++ b/tests/ui/test_role_display_rtl.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import jinja2
+
+
+def test_role_display_rtl(tmp_path):
+    templates = Path("src/ui/templates")
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates)))
+    template = env.get_template("auth_dashboard.html")
+    html = template.render(principal={"role": "ADMIN", "center_scope": "ALL"})
+    assert "dir=\"rtl\"" in html
+    assert "ADMIN" in html
+    assert "ALL" in html


### PR DESCRIPTION
## Summary
- add a reusable DebugContextFactory with default bindings and contextvar plumbing for request-scoped snapshots
- register a LogEnricher via bootstrap_logging so JSON logs include masked debug_context when enabled by DEBUG_CONTEXT_ENABLE
- reset debug context on SSO callbacks and extend the runbook with retry exhaustion/backoff guidance

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/debug/test_debug_context_fixture.py tests/debug/test_debug_context_default_factory_integration.py -p pytest_asyncio`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/docs/test_runbook_metrics_section.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/mw/test_order_auth_callback.py -p pytest_asyncio`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/auth/test_oidc_flow.py -p pytest_asyncio`

------
https://chatgpt.com/codex/tasks/task_e_68daec1cffd883218b0c0d69fa56386b