### PR TITLE
Add quality gates and deterministic test harnesses

### DIFF
--- a/.github/workflows/ci-min.yml
+++ b/.github/workflows/ci-min.yml
@@ -1,0 +1,29 @@
+name: CI (minimal)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+      TZ: Asia/Tehran
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+
+      - name: Run tests
+        run: pytest -q -W error

--- a/.github/workflows/ci-min.yml
+++ b/.github/workflows/ci-min.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install project
         run: |
           python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
           python -m pip install .[test]
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt || true
+          pip install .[test]
 
       - name: Sanity check import
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt || true
-          pip install .[test]
+          python -m pip install -r requirements.txt -r requirements-dev.txt || true
+          python -m pip install .[test]
 
       - name: Sanity check import
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,67 @@
+name: Quality Gates
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    env:
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+      TZ: Asia/Tehran
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev,test]
+
+      - name: Ruff lint
+        run: >-
+          python -m ruff check \
+            tools/bom_guard.py \
+            tools/strip_bom.py \
+            tests/ci/conftest.py \
+            tests/ci/test_bom_guard.py \
+            tests/ci/test_ruff_gate.py \
+            tests/ci/test_mypy_strict.py \
+            tests/ci/test_pydocstyle_gate.py \
+            tests/export/test_xlsx_excel_safety.py \
+            tests/export/test_atomic_finalize.py \
+            tests/security/test_metrics_protection_all_apps.py \
+            tests/mw/test_middleware_order_all_apps.py \
+            tests/perf/test_perf_gates.py
+
+      - name: Mypy strict
+        run: python -m mypy --config-file pyproject.toml
+
+      - name: Pydocstyle
+        run: >-
+          python -m pydocstyle \
+            tools/bom_guard.py \
+            tools/strip_bom.py \
+            tests/ci/conftest.py \
+            tests/ci/test_bom_guard.py \
+            tests/ci/test_ruff_gate.py \
+            tests/ci/test_mypy_strict.py \
+            tests/ci/test_pydocstyle_gate.py \
+            tests/export/test_xlsx_excel_safety.py \
+            tests/export/test_atomic_finalize.py \
+            tests/security/test_metrics_protection_all_apps.py \
+            tests/mw/test_middleware_order_all_apps.py \
+            tests/perf/test_perf_gates.py
+
+      - name: UTF-8 BOM guard
+        run: python tools/bom_guard.py --json
+
+      - name: CI tests
+        run: pytest -q -W error tests/ci

--- a/config/performance_thresholds.json
+++ b/config/performance_thresholds.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "allocation_benchmark": 250.0,
   "ui_render_benchmark": 400.0
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,95 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "student-mentor-allocation-system"
+version = "0.0.0"
+description = "Student Mentor Allocation System tooling and services."
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT License"}
+authors = [{name = "Reza", email = "ops@example.invalid"}]
+keywords = ["education", "mentoring", "allocation"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.5.0",
+    "mypy>=1.8.0",
+    "pydocstyle>=6.3.0",
+    "pre-commit>=3.5.0",
+]
+test = [
+    "pytest>=7.4",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=4.1",
+    "build>=1.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "I",
+    "B",
+    "C90",
+    "PL",
+    "RUF",
+]
+ignore = ["E203"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D100", "D103"]
+
+[tool.ruff.lint.pylint]
+max-statements = 120
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_configs = true
+files = [
+    "tools/bom_guard.py",
+    "tools/strip_bom.py",
+    "tests/ci/conftest.py",
+    "tests/ci/test_bom_guard.py",
+    "tests/ci/test_ruff_gate.py",
+    "tests/ci/test_mypy_strict.py",
+    "tests/ci/test_pydocstyle_gate.py",
+]
+enable_error_code = "ignore-without-code"
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["tests.packaging.conftest"]
+ignore_errors = false
+
+[tool.pydocstyle]
+convention = "pep257"
+match = "(?!test_).*[.]py"
+add-ignore = ["D104", "D203", "D213"]
+
+[tool.pytest.ini_options]
+filterwarnings = ["error"]
+addopts = "-q"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ test = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
     "build>=1.0",
+    "freezegun>=1.3.1",
 ]
 
 [tool.setuptools]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,10 @@
 [pytest]
-addopts = -q -p no:pytestqt
+addopts = -q -W error
 pythonpath = src .
 testpaths = tests
+required_plugins =
+env =
+    TZ=Asia/Tehran
 python_files =
     test_asgi_retry.py
     test_retry_metrics.py
@@ -40,5 +43,4 @@ markers =
     stress: آزمون‌های تنش و حجم بالا.
     asyncio: آزمون‌های مبتنی بر حلقهٔ رویداد asyncio.
     ui: آزمون‌های رابط کاربری Qt و مسیرهای دیداری.
-filterwarnings =
-    error
+filterwarnings = error

--- a/run_stable_tests.py
+++ b/run_stable_tests.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import subprocess

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 import logging

--- a/scripts/rollback_changes.py
+++ b/scripts/rollback_changes.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 """Rollback helper for reverting the most recent commit safely.
 

--- a/setup.py
+++ b/setup.py
@@ -1,158 +1,49 @@
-import json
+"""Compatibility shim for legacy tooling.
+
+This repository now uses pyproject.toml with setuptools.build_meta. Any direct
+invocation of setup.py should fail fast with a deterministic Persian message so
+that CI systems remain non-interactive.
+"""
+
+from __future__ import annotations
+
 import os
-import platform
-import stat
-import subprocess
 import sys
-from pathlib import Path
-from typing import Optional
+from typing import Iterable
+
+_ERROR_MESSAGE = (
+    "اجرای setup.py پشتیبانی نمی‌شود؛ لطفاً از «pip install .[test]» یا "
+    "«python -m build» بر پایهٔ pyproject.toml استفاده کنید."
+)
+_ALLOWED_AUTOMATION_COMMANDS: frozenset[str] = frozenset(
+    {"egg_info", "build", "sdist", "bdist_wheel"}
+)
+_BANNED_COMMANDS: frozenset[str] = frozenset({"install", "develop"})
 
 
-MIN_PYTHON = (3, 8)
+def _load_setup_callable():
+    try:
+        from setuptools import setup as setup_callable  # type: ignore import-not-found
+    except ImportError as exc:  # pragma: no cover - defensive branch
+        raise SystemExit(_ERROR_MESSAGE) from exc
+    return setup_callable
 
 
-def check_python_version() -> bool:
-    """Ensure the interpreter meets the minimum supported version."""
-    current = sys.version_info[:2]
-    if current < MIN_PYTHON:
-        print(
-            f"⚠️ Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ required (you have {current[0]}.{current[1]})"
-        )
-        return False
-    return True
-
-
-def set_pythonpath(project_root: Optional[Path] = None) -> str:
-    """Set PYTHONPATH to the project root for the current process."""
-    root = (project_root or Path.cwd()).resolve()
-    os.environ["PYTHONPATH"] = str(root)
-    print(f"✅ PYTHONPATH set to {root}")
-    return os.environ["PYTHONPATH"]
-
-
-def _install_from_requirements(requirements_file: str, label: str) -> bool:
-    path = Path(requirements_file)
-    if not path.exists():
-        print(f"⚠️ {requirements_file} not found. Skipping {label} dependencies.")
+def _is_automation_invocation(args: Iterable[str]) -> bool:
+    if os.environ.get("PIP_BUILD_TRACKER"):
         return True
-
-    print(f"📦 Installing {label} dependencies from {requirements_file}...")
-    try:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-r", str(path)],
-            check=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        print(f"❌ Failed to install dependencies from {requirements_file}: {exc}")
-        return False
-    return True
-
-
-def install_dependencies(advanced: bool = False, ml: bool = False) -> bool:
-    """Install base and optional dependency groups."""
-    ok = _install_from_requirements("requirements.txt", "base")
-    if advanced and ok:
-        ok = _install_from_requirements("requirements-advanced.txt", "advanced testing")
-    if ml and ok:
-        ok = _install_from_requirements("requirements-ml.txt", "ML")
-    return ok
-
-
-def setup_vscode_settings() -> None:
-    """Create or update VS Code settings for a smoother workflow."""
-    vscode_dir = Path(".vscode")
-    vscode_dir.mkdir(exist_ok=True)
-
-    settings_file = vscode_dir / "settings.json"
-    settings: dict = {}
-    if settings_file.exists():
-        try:
-            with settings_file.open("r", encoding="utf-8") as handle:
-                settings = json.load(handle)
-        except (json.JSONDecodeError, OSError) as exc:
-            print(f"⚠️ Could not read existing VS Code settings ({exc}). Overwriting.")
-            settings = {}
-
-    settings.update(
-        {
-            "python.linting.enabled": True,
-            "python.linting.pylintEnabled": True,
-            "python.testing.pytestEnabled": True,
-            "python.testing.unittestEnabled": False,
-            "python.testing.nosetestsEnabled": False,
-            "python.testing.pytestArgs": ["tests"],
-            "python.envFile": "${workspaceFolder}/.env",
-        }
-    )
-
-    with settings_file.open("w", encoding="utf-8") as handle:
-        json.dump(settings, handle, indent=4)
-
-    print(f"✅ VSCode settings updated at {settings_file}")
-
-    env_file = Path(".env")
-    if not env_file.exists():
-        env_file.write_text("PYTHONPATH=${workspaceFolder}\n", encoding="utf-8")
-        print(f"✅ Created .env file at {env_file}")
-
-
-def create_activation_scripts() -> None:
-    """Create activation helper scripts for Windows and Unix shells."""
-    windows_content = (
-        "@echo off\n"
-        "set PYTHONPATH=%CD%\n"
-        "echo Environment activated. PYTHONPATH set to %CD%\n"
-    )
-    Path("activate.bat").write_text(windows_content, encoding="utf-8")
-
-    posix_content = (
-        "#!/bin/bash\n"
-        "export PYTHONPATH=\"$(pwd)\"\n"
-        "echo \"Environment activated. PYTHONPATH set to $(pwd)\"\n"
-    )
-    activate_sh = Path("activate.sh")
-    activate_sh.write_text(posix_content, encoding="utf-8")
-
-    try:
-        current_mode = activate_sh.stat().st_mode
-        activate_sh.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    except OSError as exc:
-        print(f"⚠️ Could not mark activate.sh as executable: {exc}")
-
-    print("✅ Created activation scripts (activate.bat and activate.sh)")
+    return any(arg in _ALLOWED_AUTOMATION_COMMANDS for arg in args)
 
 
 def main() -> int:
-    print("🚀 Setting up testing environment...")
-
-    if not check_python_version():
-        return 1
-
-    try:
-        advanced = input("Install advanced testing dependencies? (y/N): ").strip().lower() == "y"
-        ml = input("Install ML dependencies for prediction features? (y/N): ").strip().lower() == "y"
-    except (EOFError, KeyboardInterrupt):
-        print("\n⚠️ Setup cancelled by user input.")
-        return 1
-
-    if not install_dependencies(advanced, ml):
-        print("❌ Dependency installation failed. Resolve the issues above and re-run setup.")
-        return 1
-
-    set_pythonpath()
-    setup_vscode_settings()
-    create_activation_scripts()
-
-    print("\n🎉 Setup complete! You can now run tests with:")
-    print("  - VS Code: F1 > 'Tasks: Run Task' > Select test task")
-    print("  - Terminal: make test-quick or python test_runner.py --mode quick")
-    print("\nTo activate the environment in a new terminal:")
-    if platform.system() == "Windows":
-        print("  - Run: activate.bat")
-    else:
-        print("  - Run: source ./activate.sh")
-
-    return 0
+    args = tuple(sys.argv[1:])
+    if not args or any(arg in _BANNED_COMMANDS for arg in args):
+        raise SystemExit(_ERROR_MESSAGE)
+    if _is_automation_invocation(args):
+        setup_callable = _load_setup_callable()
+        setup_callable()
+        return 0
+    raise SystemExit(_ERROR_MESSAGE)
 
 
 if __name__ == "__main__":

--- a/src/ops/ratelimit_metrics.py
+++ b/src/ops/ratelimit_metrics.py
@@ -1,0 +1,51 @@
+"""Rate limit observability helpers for deterministic tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from prometheus_client import CollectorRegistry, Counter, Gauge
+
+
+@dataclass(slots=True)
+class RateLimitMetrics:
+    namespace: str
+    registry: CollectorRegistry
+    tokens: Gauge
+    drops_total: Counter
+
+    def set_tokens(self, *, route: str, remaining: int) -> None:
+        self.tokens.labels(route=route).set(max(0, remaining))
+
+    def record_drop(self, *, route: str) -> None:
+        self.drops_total.labels(route=route).inc()
+
+
+def build_rate_limit_metrics(namespace: str, registry: CollectorRegistry | None = None) -> RateLimitMetrics:
+    reg = registry or CollectorRegistry()
+    gauge_name = f"{namespace}_ratelimit_tokens"
+    counter_name = f"{namespace}_ratelimit_drops_total"
+    tokens = _get_or_create_gauge(reg, gauge_name, "Remaining tokens per route.", ("route",))
+    drops_total = _get_or_create_counter(reg, counter_name, "Rate limit drops per route.", ("route",))
+    return RateLimitMetrics(namespace=namespace, registry=reg, tokens=tokens, drops_total=drops_total)
+
+
+def _get_or_create_gauge(
+    registry: CollectorRegistry, name: str, documentation: str, labelnames: tuple[str, ...]
+) -> Gauge:
+    existing = getattr(registry, "_names_to_collectors", {}).get(name)
+    if isinstance(existing, Gauge):
+        return existing
+    return Gauge(name, documentation, registry=registry, labelnames=labelnames)
+
+
+def _get_or_create_counter(
+    registry: CollectorRegistry, name: str, documentation: str, labelnames: tuple[str, ...]
+) -> Counter:
+    existing = getattr(registry, "_names_to_collectors", {}).get(name)
+    if isinstance(existing, Counter):
+        return existing
+    return Counter(name, documentation, registry=registry, labelnames=labelnames)
+
+
+__all__ = ["RateLimitMetrics", "build_rate_limit_metrics"]

--- a/src/ops/retry.py
+++ b/src/ops/retry.py
@@ -1,0 +1,99 @@
+"""Retry observability helpers with deterministic jitter hooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, TypeVar
+
+from prometheus_client import CollectorRegistry, Counter, Histogram
+
+T = TypeVar("T")
+
+_BACKOFF_BUCKETS: tuple[float, ...] = (0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0)
+
+
+@dataclass(slots=True)
+class RetryMetrics:
+    """Aggregated retry counters honoring AGENTS.md::Observability & No PII."""
+
+    namespace: str
+    registry: CollectorRegistry
+    attempts_total: Counter
+    exhaustion_total: Counter
+    backoff_seconds: Histogram
+
+    def record_attempts(self, *, operation: str, outcome: str, attempts: int) -> None:
+        self.attempts_total.labels(operation=operation, namespace=self.namespace, outcome=outcome).inc(attempts)
+
+    def record_exhaustion(self, *, operation: str) -> None:
+        self.exhaustion_total.labels(operation=operation, namespace=self.namespace).inc()
+
+    def observe_backoff(self, *, operation: str, delays: Iterable[float]) -> None:
+        for delay in delays:
+            self.backoff_seconds.labels(operation=operation, namespace=self.namespace).observe(delay)
+
+
+def build_retry_metrics(namespace: str, registry: CollectorRegistry | None = None) -> RetryMetrics:
+    reg = registry or CollectorRegistry()
+    attempts_total = Counter(
+        f"{namespace}_retry_attempts_total",
+        "Retry attempts recorded by operation and outcome.",
+        registry=reg,
+        labelnames=("operation", "namespace", "outcome"),
+    )
+    exhaustion_total = Counter(
+        f"{namespace}_retry_exhaustion_total",
+        "Retry exhaustion occurrences by operation.",
+        registry=reg,
+        labelnames=("operation", "namespace"),
+    )
+    backoff_seconds = Histogram(
+        f"{namespace}_retry_backoff_seconds",
+        "Retry backoff schedule seconds by operation.",
+        registry=reg,
+        labelnames=("operation", "namespace"),
+        buckets=_BACKOFF_BUCKETS,
+    )
+    return RetryMetrics(
+        namespace=namespace,
+        registry=reg,
+        attempts_total=attempts_total,
+        exhaustion_total=exhaustion_total,
+        backoff_seconds=backoff_seconds,
+    )
+
+
+def execute_with_retry(
+    operation: Callable[[], T],
+    *,
+    policy: Callable[[int], float],
+    max_attempts: int,
+    metrics: RetryMetrics,
+    clock_tick: Callable[[float], None],
+    operation_name: str,
+) -> T:
+    attempts = 0
+    delays: list[float] = []
+    last_error: Exception | None = None
+    while attempts < max_attempts:
+        attempts += 1
+        try:
+            result = operation()
+            metrics.observe_backoff(operation=operation_name, delays=delays)
+            metrics.record_attempts(operation=operation_name, outcome="success", attempts=attempts)
+            return result
+        except Exception as exc:  # pragma: no cover - raised in tests
+            last_error = exc
+            if attempts >= max_attempts:
+                break
+            delay = policy(attempts)
+            delays.append(delay)
+            clock_tick(delay)
+    metrics.observe_backoff(operation=operation_name, delays=delays)
+    metrics.record_attempts(operation=operation_name, outcome="error", attempts=attempts)
+    metrics.record_exhaustion(operation=operation_name)
+    assert last_error is not None, "retry_exhaustion_missing_error"
+    raise last_error
+
+
+__all__ = ["RetryMetrics", "build_retry_metrics", "execute_with_retry"]

--- a/src/phase6_import_to_sabt/middleware/metrics.py
+++ b/src/phase6_import_to_sabt/middleware/metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 
 @dataclass(slots=True)
@@ -15,10 +15,25 @@ class MiddlewareMetrics:
     rate_limit_latency_seconds: Histogram
     idempotency_latency_seconds: Histogram
     auth_latency_seconds: Histogram
+    rate_limit_tokens: Gauge
+    rate_limit_drops_total: Counter
 
-    def observe_rate_limit(self, decision: str, duration: float) -> None:
+    def observe_rate_limit(
+        self,
+        decision: str,
+        duration: float,
+        *,
+        route: str | None = None,
+        remaining: int | None = None,
+        capacity: int | None = None,
+    ) -> None:
         self.rate_limit_decision_total.labels(decision=decision).inc()
         self.rate_limit_latency_seconds.observe(duration)
+        if route is not None and remaining is not None and capacity is not None:
+            bounded_remaining = max(0, min(remaining, capacity))
+            self.rate_limit_tokens.labels(route=route).set(bounded_remaining)
+            if decision == "block":
+                self.rate_limit_drops_total.labels(route=route).inc()
 
     def observe_idempotency(self, outcome: str, duration: float) -> None:
         self.idempotency_hits_total.labels(outcome=outcome).inc()

--- a/src/services/config_manager.py
+++ b/src/services/config_manager.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 import os

--- a/src/services/performance_monitor.py
+++ b/src/services/performance_monitor.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import time
 from datetime import datetime

--- a/src/ui/components/analytics_dashboard.py
+++ b/src/ui/components/analytics_dashboard.py
@@ -1,1 +1,1 @@
-﻿from ..widgets.analytics_dashboard import AnalyticsDashboard  # noqa: F401
+from ..widgets.analytics_dashboard import AnalyticsDashboard  # noqa: F401

--- a/src/ui/dialogs/settings_dialog.py
+++ b/src/ui/dialogs/settings_dialog.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from dataclasses import asdict
 from typing import Dict, Optional

--- a/src/ui/models/mentors_model.py
+++ b/src/ui/models/mentors_model.py
@@ -1,4 +1,4 @@
-﻿"""Qt table model for mentor listings."""
+"""Qt table model for mentor listings."""
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional

--- a/src/ui/pages/allocation_presenter.py
+++ b/src/ui/pages/allocation_presenter.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import inspect
 from dataclasses import replace

--- a/src/ui/pages/mentors_page.py
+++ b/src/ui/pages/mentors_page.py
@@ -1,4 +1,4 @@
-﻿"""Mentor management UI page."""
+"""Mentor management UI page."""
 from __future__ import annotations
 
 import logging

--- a/src/ui/services/allocation_backend.py
+++ b/src/ui/services/allocation_backend.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod

--- a/src/ui/services/config_manager.py
+++ b/src/ui/services/config_manager.py
@@ -1,1 +1,1 @@
-﻿from ...services.config_manager import ConfigManager  # noqa: F401
+from ...services.config_manager import ConfigManager  # noqa: F401

--- a/src/ui/services/excel_exporter.py
+++ b/src/ui/services/excel_exporter.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from typing import Dict, List
 

--- a/src/ui/services/mock_mentor_service.py
+++ b/src/ui/services/mock_mentor_service.py
@@ -1,4 +1,4 @@
-﻿"""Mock service for mentor management to support UI development."""
+"""Mock service for mentor management to support UI development."""
 from __future__ import annotations
 
 from datetime import datetime

--- a/src/ui/services/performance_monitor.py
+++ b/src/ui/services/performance_monitor.py
@@ -1,1 +1,1 @@
-﻿from ...services.performance_monitor import PerformanceMonitor  # noqa: F401
+from ...services.performance_monitor import PerformanceMonitor  # noqa: F401

--- a/src/ui/widgets/analytics_dashboard.py
+++ b/src/ui/widgets/analytics_dashboard.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from datetime import datetime
 from typing import Dict, Optional

--- a/tests/ci/conftest.py
+++ b/tests/ci/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for deterministic CI quality gates."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from tests.packaging import conftest as packaging_conftest
+
+
+@pytest.fixture
+def packaging_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[packaging_conftest.PackagingState]:
+    """Provide a reusable packaging state with deterministic cleanup."""
+    packaging_conftest._cleanup_targets(packaging_conftest.PROJECT_ROOT)
+    namespace = hashlib.blake2s(str(tmp_path).encode("utf-8"), digest_size=6).hexdigest()
+    workspace = tmp_path / f"wheelhouse-{namespace}"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PYTHONHASHSEED", "0")
+    monkeypatch.setenv("TZ", "Asia/Tehran")
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1704067200")
+
+    env = dict(os.environ)
+    state = packaging_conftest.PackagingState(
+        root=packaging_conftest.PROJECT_ROOT,
+        env=env,
+        namespace=namespace,
+        workspace=workspace,
+    )
+    try:
+        yield state
+    finally:
+        state.cleanup()
+        packaging_conftest._cleanup_targets(packaging_conftest.PROJECT_ROOT)

--- a/tests/ci/test_bom_guard.py
+++ b/tests/ci/test_bom_guard.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.packaging.conftest import CommandResult, PackagingState, get_debug_context
+from tools.bom_guard import BOM
+
+_ANCHOR = "AGENTS.md::Determinism & CI"
+
+
+@pytest.mark.usefixtures("packaging_state")
+def test_no_bom_in_source_tree(packaging_state: PackagingState) -> None:
+    result: CommandResult = packaging_state.run(
+        ("python", "tools/bom_guard.py", "--json"),
+        expect_success=True,
+    )
+    payload = json.loads(result.stdout or "{}")
+    context = get_debug_context(packaging_state, result)
+    context.update({"payload": payload, "evidence": _ANCHOR})
+    assert payload.get("bom_findings") == [], context
+
+    bom_target = packaging_state.workspace / "bom-fixture.json"
+    bom_target.write_bytes(BOM + b"{}")
+    failing: CommandResult = packaging_state.run(
+        ("python", "tools/bom_guard.py", "--paths", str(bom_target)),
+        expect_success=False,
+    )
+    failing_context = get_debug_context(packaging_state, failing)
+    failing_context.update({"stdout": failing.stdout, "stderr": failing.stderr})
+    message = (failing.stdout or failing.stderr or "{}").strip()
+    assert "bom_findings" in message, failing_context
+    assert str(bom_target) in message, failing_context

--- a/tests/ci/test_mypy_strict.py
+++ b/tests/ci/test_mypy_strict.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.packaging.conftest import CommandResult, PackagingState, get_debug_context
+
+_ANCHOR = "AGENTS.md::Determinism & CI"
+
+
+@pytest.mark.usefixtures("packaging_state")
+def test_mypy_strict(packaging_state: PackagingState) -> None:
+    command = ("python", "-m", "mypy", "--config-file", "pyproject.toml")
+    result: CommandResult = packaging_state.run(command, expect_success=True)
+    context = get_debug_context(packaging_state, result)
+    context.update({"stdout": result.stdout, "stderr": result.stderr, "evidence": _ANCHOR})
+    assert "Success: no issues found" in (result.stdout or ""), context

--- a/tests/ci/test_pydocstyle_gate.py
+++ b/tests/ci/test_pydocstyle_gate.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.packaging.conftest import CommandResult, PackagingState, get_debug_context
+
+_ANCHOR = "AGENTS.md::Determinism & CI"
+_TARGETS = (
+    "tools/bom_guard.py",
+    "tools/strip_bom.py",
+    "tests/ci/conftest.py",
+    "tests/ci/test_bom_guard.py",
+    "tests/ci/test_ruff_gate.py",
+    "tests/ci/test_mypy_strict.py",
+    "tests/ci/test_pydocstyle_gate.py",
+    "tests/export/test_xlsx_excel_safety.py",
+    "tests/export/test_atomic_finalize.py",
+    "tests/security/test_metrics_protection_all_apps.py",
+    "tests/mw/test_middleware_order_all_apps.py",
+    "tests/perf/test_perf_gates.py",
+)
+
+
+@pytest.mark.usefixtures("packaging_state")
+def test_pydocstyle_gate(packaging_state: PackagingState) -> None:
+    command = ("python", "-m", "pydocstyle", *_TARGETS)
+    result: CommandResult = packaging_state.run(command, expect_success=True)
+    context = get_debug_context(packaging_state, result)
+    context.update(
+        {
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "targets": _TARGETS,
+            "evidence": _ANCHOR,
+        }
+    )
+    assert not (result.stdout or result.stderr), context

--- a/tests/ci/test_ruff_gate.py
+++ b/tests/ci/test_ruff_gate.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.packaging.conftest import CommandResult, PackagingState, get_debug_context
+
+_ANCHOR = "AGENTS.md::Determinism & CI"
+_TARGETS = (
+    "tools/bom_guard.py",
+    "tools/strip_bom.py",
+    "tests/ci/conftest.py",
+    "tests/ci/test_bom_guard.py",
+    "tests/ci/test_ruff_gate.py",
+    "tests/ci/test_mypy_strict.py",
+    "tests/ci/test_pydocstyle_gate.py",
+    "tests/export/test_xlsx_excel_safety.py",
+    "tests/export/test_atomic_finalize.py",
+    "tests/security/test_metrics_protection_all_apps.py",
+    "tests/mw/test_middleware_order_all_apps.py",
+    "tests/perf/test_perf_gates.py",
+)
+
+
+@pytest.mark.usefixtures("packaging_state")
+def test_ruff_gate(packaging_state: PackagingState) -> None:
+    command = ("python", "-m", "ruff", "check", *_TARGETS)
+    result: CommandResult = packaging_state.run(command, expect_success=True)
+    context = get_debug_context(packaging_state, result)
+    context.update(
+        {
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "targets": _TARGETS,
+            "evidence": _ANCHOR,
+        }
+    )
+    assert "warning" not in (result.stdout or "").lower(), context
+    assert result.returncode == 0, context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,96 @@
+"""Shared pytest fixtures respecting AGENTS determinism guidance."""
+
+from __future__ import annotations
+
 import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterator
+
+import pytest
+
 
 os.environ.setdefault("RUN_PERFORMANCE_SUITE", "1")
 
-pytest_plugins = [
+
+pytest_plugins = (
+    "pytest_asyncio",
     "tests.audit_retention.conftest",
     "tests.auth.conftest",
     "tests.fixtures.state",
     "tests.fixtures.debug_context",
+    "tests.fixtures.factories",
     "tests.ops.conftest",
     "tests.plugins.pytest_asyncio_compat",
     "tests.plugins.session_stats",
     "tests.uploads.conftest",
     "pytester",
-]
+)
 
-__all__ = ["pytest_plugins"]
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addini("env", "Environment variables for deterministic testing.", type="linelist", default=[])
+    try:
+        parser.addini(
+            "asyncio_default_fixture_loop_scope",
+            "Default asyncio fixture loop scope registered for pytest-asyncio.",
+            default="function",
+        )
+    except ValueError:
+        # Already registered by pytest-asyncio; ignore to keep determinism.
+        pass
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    for item in config.getini("env"):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+if os.environ.get("TZ") != "Asia/Tehran":
+    os.environ["TZ"] = "Asia/Tehran"
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+
+_TEHRAN_TZ = timezone(timedelta(hours=3, minutes=30))
+
+
+@dataclass
+class DeterministicClock:
+    """Deterministic clock aligned with AGENTS.md::Determinism."""
+
+    _current: datetime
+
+    def __call__(self) -> datetime:
+        return self._current
+
+    def now(self) -> datetime:
+        return self._current
+
+    def tick(self, *, seconds: float = 0.0) -> datetime:
+        delta = timedelta(seconds=seconds)
+        self._current = self._current + delta
+        return self._current
+
+    def freeze(self, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=_TEHRAN_TZ)
+        self._current = value.astimezone(_TEHRAN_TZ)
+        return self._current
+
+
+@pytest.fixture()
+def clock() -> Iterator[DeterministicClock]:
+    """Provide deterministic time control per AGENTS.md::Testing & CI Gates."""
+
+    timeline = DeterministicClock(
+        _current=datetime(2024, 1, 1, 0, 0, tzinfo=_TEHRAN_TZ)
+    )
+    try:
+        yield timeline
+    finally:
+        timeline.freeze(datetime(2024, 1, 1, 0, 0, tzinfo=_TEHRAN_TZ))

--- a/tests/export/test_atomic_finalize.py
+++ b/tests/export/test_atomic_finalize.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import os
+
 import pytest
 
 from src.phase6_import_to_sabt.xlsx.metrics import build_import_export_metrics
 from src.phase6_import_to_sabt.xlsx.utils import atomic_write
 
+_ANCHOR = "AGENTS.md::Atomic I/O & Excel-Safety"
 
-def test_atomic_rename_and_fsync(cleanup_fixtures, monkeypatch) -> None:
+
+def test_part_rename_fsync(cleanup_fixtures, monkeypatch) -> None:
     output_dir = cleanup_fixtures.base_dir / "atomic"
     output_dir.mkdir(parents=True, exist_ok=True)
     target = output_dir / "export.bin"
@@ -22,19 +25,29 @@ def test_atomic_rename_and_fsync(cleanup_fixtures, monkeypatch) -> None:
 
     monkeypatch.setattr("src.phase6_import_to_sabt.xlsx.utils.os.fsync", capture_fsync)
 
-    with atomic_write(target, metrics=metrics, format_label="xlsx", sleeper=lambda _: None) as handle:
+    with atomic_write(
+        target,
+        metrics=metrics,
+        format_label="xlsx",
+        sleeper=lambda _: None,
+    ) as handle:
         handle.write(b"data")
 
-    debug_context = cleanup_fixtures.context(target=str(target))
+    debug_context = cleanup_fixtures.context(target=str(target), evidence=_ANCHOR)
     assert target.exists(), debug_context
     assert fsync_calls, {"debug": debug_context, "fsync_calls": fsync_calls}
     assert not list(output_dir.glob("*.part")), debug_context
     assert target.read_bytes() == b"data", debug_context
 
     failing_target = output_dir / "error.bin"
-    error_context = cleanup_fixtures.context(target=str(failing_target))
+    error_context = cleanup_fixtures.context(target=str(failing_target), evidence=_ANCHOR)
     with pytest.raises(RuntimeError):
-        with atomic_write(failing_target, metrics=metrics, format_label="xlsx", sleeper=lambda _: None) as handle:
+        with atomic_write(
+            failing_target,
+            metrics=metrics,
+            format_label="xlsx",
+            sleeper=lambda _: None,
+        ) as handle:
             handle.write(b"payload")
             raise RuntimeError("forced failure")
     assert not failing_target.exists(), error_context

--- a/tests/export/test_xlsx_excel_safety.py
+++ b/tests/export/test_xlsx_excel_safety.py
@@ -9,6 +9,8 @@ from src.phase6_import_to_sabt.xlsx.constants import SENSITIVE_COLUMNS
 from src.phase6_import_to_sabt.xlsx.metrics import build_import_export_metrics
 from src.phase6_import_to_sabt.xlsx.writer import XLSXStreamWriter
 
+_ANCHOR = "AGENTS.md::Atomic I/O & Excel-Safety"
+
 
 def test_formula_guard_and_sensitive_as_text(cleanup_fixtures) -> None:
     writer = XLSXStreamWriter(chunk_size=8)
@@ -45,7 +47,7 @@ def test_formula_guard_and_sensitive_as_text(cleanup_fixtures) -> None:
         format_label="xlsx",
         sleeper=lambda _: None,
     )
-    debug_context = cleanup_fixtures.context(export_path=str(output_path))
+    debug_context = cleanup_fixtures.context(export_path=str(output_path), evidence=_ANCHOR)
     assert artifact.excel_safety["formula_guard"], debug_context
     workbook = load_workbook(output_path, data_only=False)
     sheet = workbook.active

--- a/tests/fixtures/retry.py
+++ b/tests/fixtures/retry.py
@@ -1,0 +1,74 @@
+"""Deterministic retry tooling honoring AGENTS.md::Determinism."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Callable, Iterator, Protocol, TypeVar
+
+import pytest
+
+from tests.conftest import DeterministicClock
+
+_ANCHOR = "AGENTS.md::Determinism"
+_MIN_DELAY = 0.0
+
+
+class Operation(Protocol):
+    def __call__(self) -> object:  # pragma: no cover - protocol signature
+        ...
+
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class DeterministicBackoffPolicy:
+    """Compute deterministic BLAKE2 jitter for retries."""
+
+    operation: str
+    namespace: str
+    route: str = ""
+    base_delay: float = 0.05
+    multiplier: float = 2.0
+
+    def compute(self, attempt: int) -> float:
+        seed_base = f"{self.namespace}:{self.operation}:{self.route}".encode("utf-8")
+        seed = seed_base + f":{attempt}".encode("utf-8")
+        digest = hashlib.blake2s(seed, digest_size=8).digest()
+        jitter = int.from_bytes(digest, "big") / float(1 << 64)
+        factor = 0.5 + jitter  # ensures deterministic but bounded scaling
+        delay = self.base_delay * (self.multiplier ** max(attempt - 1, 0)) * factor
+        return max(_MIN_DELAY, round(delay, 6))
+
+
+def execute_with_policy(
+    operation: Callable[[], T],
+    *,
+    policy: DeterministicBackoffPolicy,
+    clock: DeterministicClock,
+    max_attempts: int,
+) -> T:
+    attempts = 0
+    last_error: Exception | None = None
+    while attempts < max_attempts:
+        attempts += 1
+        try:
+            return operation()
+        except Exception as exc:  # pragma: no cover - exercised in tests
+            last_error = exc
+            if attempts >= max_attempts:
+                break
+            delay = policy.compute(attempts)
+            clock.tick(seconds=delay)
+    assert last_error is not None, {"anchor": _ANCHOR, "reason": "missing error"}
+    raise last_error
+
+
+@pytest.fixture()
+def retry_policy(clock: DeterministicClock) -> Iterator[DeterministicBackoffPolicy]:
+    policy = DeterministicBackoffPolicy(operation="test.op", namespace=clock.now().isoformat())
+    yield policy
+
+
+__all__ = ["DeterministicBackoffPolicy", "execute_with_policy", "retry_policy"]

--- a/tests/helpers/http_retry.py
+++ b/tests/helpers/http_retry.py
@@ -135,6 +135,8 @@ async def asgi_request_with_retry(
         attempt = 1
         while attempt <= max_attempts:
             delay = _compute_delay(base_delay, attempt, jitter_seed)
+            if metrics is not None:
+                metrics.retry_backoff_seconds.labels(operation=operation, route=path).observe(delay)
             _increment_attempt_metric(metrics, operation, path, exhausted=False)
             try:
                 response = await client.request(

--- a/tests/obs/conftest.py
+++ b/tests/obs/conftest.py
@@ -1,0 +1,9 @@
+"""Load pytest-asyncio explicitly for observability suites."""
+
+from __future__ import annotations
+
+pytest_plugins = ("pytest_asyncio",)
+
+
+def pytest_configure(config):  # type: ignore[no-untyped-def]
+    config.addinivalue_line("markers", "asyncio: آزمون‌های مبتنی بر حلقهٔ رویداد asyncio.")

--- a/tests/packaging/conftest.py
+++ b/tests/packaging/conftest.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CLEAN_TARGETS: Sequence[str] = ("build", "dist", "*.egg-info", "pip-wheel-metadata")
+_EVIDENCE_ANCHOR = "AGENTS.md::Determinism & CI"
+
+
+@dataclass
+class CommandResult:
+    command: Sequence[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    planned_backoff: List[float] = field(default_factory=list)
+
+
+@dataclass
+class PackagingState:
+    root: Path
+    env: Dict[str, str]
+    namespace: str
+    workspace: Path
+
+    def run(self, command: Sequence[str], *, expect_success: bool) -> CommandResult:
+        attempts: List[float] = []
+        last_result: subprocess.CompletedProcess[str] | None = None
+        for attempt in range(3):
+            planned_delay = _planned_delay(self.namespace, attempt)
+            attempts.append(planned_delay)
+            result = subprocess.run(
+                command,
+                cwd=self.root,
+                env=self.env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            last_result = result
+            succeeded = result.returncode == 0
+            if expect_success and succeeded:
+                return CommandResult(command, result.returncode, result.stdout, result.stderr, attempts)
+            if not expect_success and not succeeded:
+                return CommandResult(command, result.returncode, result.stdout, result.stderr, attempts)
+        debug_context = get_debug_context(self, last_result)
+        raise AssertionError(
+            f"Command did not reach expected state after retries. Context: {debug_context}"
+        )
+
+    def cleanup(self) -> None:
+        _cleanup_targets(self.root)
+        if self.workspace.exists():
+            shutil.rmtree(self.workspace, ignore_errors=True)
+
+
+def _cleanup_targets(root: Path) -> None:
+    for pattern in _CLEAN_TARGETS:
+        for item in root.glob(pattern):
+            if item.is_dir():
+                shutil.rmtree(item, ignore_errors=True)
+            elif item.exists():
+                item.unlink(missing_ok=True)
+
+
+def _planned_delay(namespace: str, attempt: int) -> float:
+    seed = hashlib.blake2s(f"{namespace}:{attempt}".encode("utf-8"), digest_size=6).digest()
+    jitter = int.from_bytes(seed, "big") % 1000 / 10000
+    base = 0.05 * (2**attempt)
+    return float(round(base + jitter, 4))
+
+
+def get_debug_context(
+    state: PackagingState,
+    result: CommandResult | subprocess.CompletedProcess[str] | None,
+) -> Dict[str, object]:
+    return {
+        "evidence": _EVIDENCE_ANCHOR,
+        "namespace": state.namespace,
+        "cwd": str(state.root),
+        "planned_backoff": getattr(result, "planned_backoff", None),
+        "last_returncode": getattr(result, "returncode", None),
+        "stdout": getattr(result, "stdout", ""),
+        "stderr": getattr(result, "stderr", ""),
+        "env_snapshot": {
+            key: state.env[key]
+            for key in sorted({"PYTHONHASHSEED", "TZ", "SOURCE_DATE_EPOCH"} & state.env.keys())
+        },
+    }
+
+
+@pytest.fixture
+def packaging_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterable[PackagingState]:
+    _cleanup_targets(PROJECT_ROOT)
+    namespace = hashlib.blake2s(str(tmp_path).encode("utf-8"), digest_size=6).hexdigest()
+    workspace = tmp_path / f"wheelhouse-{namespace}"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PYTHONHASHSEED", "0")
+    monkeypatch.setenv("TZ", "Asia/Tehran")
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1704067200")
+    env = dict(os.environ)
+    state = PackagingState(root=PROJECT_ROOT, env=env, namespace=namespace, workspace=workspace)
+    try:
+        yield state
+    finally:
+        state.cleanup()
+        _cleanup_targets(PROJECT_ROOT)

--- a/tests/packaging/test_build_wheel.py
+++ b/tests/packaging/test_build_wheel.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.packaging.conftest import (
+    CommandResult,
+    PackagingState,
+    get_debug_context,
+)
+
+
+@pytest.mark.usefixtures("packaging_state")
+def test_build_wheel_ok(packaging_state: PackagingState) -> None:
+    wheel_dir = packaging_state.workspace
+    result: CommandResult = packaging_state.run(
+        (
+            "python",
+            "-m",
+            "pip",
+            "wheel",
+            ".",
+            "--no-deps",
+            "-w",
+            str(wheel_dir),
+        ),
+        expect_success=True,
+    )
+
+    wheels = sorted(Path(wheel_dir).glob("*.whl"))
+    context = get_debug_context(packaging_state, result)
+    context.update({"wheel_files": [wheel.name for wheel in wheels]})
+    assert wheels, f"Wheel build produced no artifacts. Context: {context}"
+    artifact_name = wheels[0].name
+    assert artifact_name.startswith("student_mentor_allocation_system-0.0.0"), (
+        f"Unexpected wheel name {artifact_name}. Context: {context}"
+    )

--- a/tests/packaging/test_pyproject_extras.py
+++ b/tests/packaging/test_pyproject_extras.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from tests.packaging.conftest import (
+    CommandResult,
+    PackagingState,
+    get_debug_context,
+)
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+@pytest.mark.usefixtures("packaging_state")
+def test_install_extras_non_interactive(packaging_state: PackagingState) -> None:
+    raw_pyproject = PYPROJECT_PATH.read_text(encoding="utf-8")
+    data = tomllib.loads(raw_pyproject)
+    project_block = data.get("project", {})
+    extras = project_block.get("optional-dependencies", {})
+
+    context = get_debug_context(packaging_state, None)
+    context.update({"extras": extras})
+
+    assert {"dev", "test"}.issubset(extras), (
+        "Missing required extras declared in pyproject.toml. Context: " f"{context}"
+    )
+    assert extras["test"], f"Test extras must not be empty. Context: {context}"
+    assert extras["dev"], f"Dev extras must not be empty. Context: {context}"
+
+    result: CommandResult = packaging_state.run(
+        ("python", "setup.py", "--version"),
+        expect_success=False,
+    )
+    message = (result.stderr or result.stdout).strip()
+    failure_context = get_debug_context(packaging_state, result)
+    assert result.returncode != 0, f"setup.py should fail-fast. Context: {failure_context}"
+    expected_fragment = "اجرای setup.py پشتیبانی نمی‌شود"
+    assert expected_fragment in message, f"Missing Persian guidance. Context: {failure_context}"
+    assert "pyproject.toml" in message, f"Message must point to pyproject.toml. Context: {failure_context}"

--- a/tests/perf/test_perf_gates.py
+++ b/tests/perf/test_perf_gates.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import time
+import tracemalloc
+from hashlib import blake2s
+
+import pytest
+
+from tests.helpers.http_retry import request_with_retry
+from tests.mw.test_middleware_order_all_apps import _build_phase6_app
+
+_ANCHOR = "AGENTS.md::Determinism"
+_P95_BUDGET_MS = 200.0
+_MEMORY_BUDGET_MB = 300.0
+_SUCCESS_STATUS = 200
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    if not samples:
+        raise ValueError("samples required")
+    sorted_samples = sorted(samples)
+    position = (len(sorted_samples) - 1) * (percentile / 100.0)
+    floor_index = int(position)
+    ceil_index = min(floor_index + 1, len(sorted_samples) - 1)
+    if floor_index == ceil_index:
+        return sorted_samples[floor_index]
+    lower_weight = ceil_index - position
+    upper_weight = position - floor_index
+    return (
+        sorted_samples[floor_index] * lower_weight
+        + sorted_samples[ceil_index] * upper_weight
+    )
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_p95_latency_and_memory(monkeypatch) -> None:
+    app = _build_phase6_app(monkeypatch)
+    headers = {
+        "Authorization": "Bearer service-token",
+        "Idempotency-Key": f"idem-{blake2s(b'perf', digest_size=4).hexdigest()}",
+        "X-Client-ID": "perf-harness",
+    }
+    durations: list[float] = []
+    peak_memory_mb = 0.0
+    token_seed = blake2s(b"perf-harness", digest_size=6).hexdigest()
+    tracemalloc.start()
+    try:
+        for attempt_index in range(8):
+            start = time.perf_counter()
+            response, retry_context = request_with_retry(
+                app,
+                "POST",
+                "/api/jobs",
+                headers=headers,
+                json={"request_id": f"perf-{token_seed}-{attempt_index}"},
+                max_attempts=1,
+                namespace=f"perf-{token_seed}",
+                jitter_seed=f"perf-{attempt_index}",
+            )
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            durations.append(elapsed_ms)
+            assert response.status_code == _SUCCESS_STATUS, json.dumps(
+                {
+                    "evidence": _ANCHOR,
+                    "status": response.status_code,
+                    "namespace": retry_context.namespace,
+                    "attempts": [entry.status_code for entry in retry_context.attempts],
+                    "duration_ms": elapsed_ms,
+                },
+                ensure_ascii=False,
+            )
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            peak_memory_mb = max(peak_memory_mb, peak_bytes / (1024 * 1024))
+    finally:
+        tracemalloc.stop()
+
+    p95 = _percentile(durations, 95.0)
+    context = {
+        "evidence": _ANCHOR,
+        "durations": durations,
+        "p95_ms": p95,
+        "peak_memory_mb": peak_memory_mb,
+    }
+    assert p95 <= _P95_BUDGET_MS, json.dumps(context, ensure_ascii=False)
+    assert peak_memory_mb <= _MEMORY_BUDGET_MB, json.dumps(context, ensure_ascii=False)

--- a/tests/performance/test_analytics_integration.py
+++ b/tests/performance/test_analytics_integration.py
@@ -1,4 +1,4 @@
-﻿import asyncio
+import asyncio
 import time
 
 import pytest

--- a/tests/ratelimit/test_rate_limit_state.py
+++ b/tests/ratelimit/test_rate_limit_state.py
@@ -1,0 +1,150 @@
+"""Rate limit state validation referencing AGENTS.md::Middleware Order."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime
+
+import httpx
+import pytest
+from prometheus_client import CollectorRegistry
+from zoneinfo import ZoneInfo
+
+from src.phase6_import_to_sabt.app.app_factory import create_application
+from src.phase6_import_to_sabt.app.clock import FixedClock
+from src.phase6_import_to_sabt.app.config import (
+    AppConfig,
+    AuthConfig,
+    DatabaseConfig,
+    ObservabilityConfig,
+    RateLimitConfig,
+    RedisConfig,
+)
+from src.phase6_import_to_sabt.app.stores import InMemoryKeyValueStore
+from src.phase6_import_to_sabt.app.timing import DeterministicTimer
+from src.phase6_import_to_sabt.obs.metrics import build_metrics
+from src.ops.ratelimit_metrics import build_rate_limit_metrics
+
+_ANCHOR = "AGENTS.md::Middleware Order"
+_EXPECTED_CHAIN = ["RateLimit", "Idempotency", "Auth"]
+
+
+def _build_rate_limited_app(monkeypatch, *, capacity: int, window: int = 60):
+    namespace = f"ratelimit-{uuid.uuid4().hex}"
+    tokens_env = f"TOKENS_{uuid.uuid4().hex}"
+    signing_env = f"SIGNING_{uuid.uuid4().hex}"
+    tokens_payload = [{"value": "T" * 32, "role": "ADMIN"}]
+    signing_payload = [{"kid": "primary", "secret": "S" * 48, "state": "active"}]
+    monkeypatch.setenv(tokens_env, json.dumps(tokens_payload, ensure_ascii=False))
+    monkeypatch.setenv(signing_env, json.dumps(signing_payload, ensure_ascii=False))
+
+    registry = CollectorRegistry()
+    metrics = build_metrics(namespace, registry=registry)
+    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Tehran")))
+    timer = DeterministicTimer([0.001] * 32)
+    rate_store = InMemoryKeyValueStore(namespace=f"{namespace}:rate", clock=clock)
+    idem_store = InMemoryKeyValueStore(namespace=f"{namespace}:idem", clock=clock)
+
+    config = AppConfig(
+        redis=RedisConfig(dsn="redis://localhost:6379/0", namespace=namespace, operation_timeout=0.1),
+        database=DatabaseConfig(dsn="postgresql://localhost/test", statement_timeout_ms=500),
+        auth=AuthConfig(
+            metrics_token="metrics-token",
+            service_token="service-token",
+            tokens_env_var=tokens_env,
+            download_signing_keys_env_var=signing_env,
+            download_url_ttl_seconds=600,
+        ),
+        ratelimit=RateLimitConfig(
+            namespace=namespace,
+            requests=capacity,
+            window_seconds=window,
+            penalty_seconds=window,
+        ),
+        observability=ObservabilityConfig(service_name="ratelimit-test", metrics_namespace=namespace),
+        timezone="Asia/Tehran",
+        readiness_timeout_seconds=0.1,
+        health_timeout_seconds=0.1,
+        enable_debug_logs=True,
+        enable_diagnostics=True,
+    )
+
+    app = create_application(
+        config,
+        clock=clock,
+        metrics=metrics,
+        timer=timer,
+        rate_limit_store=rate_store,
+        idempotency_store=idem_store,
+        readiness_probes={},
+        workflow=None,
+    )
+
+    return namespace, registry, app
+
+
+def _send_request(app, **kwargs):
+    async def _call():
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            return await client.post(**kwargs)
+
+    return asyncio.run(_call())
+
+
+def test_rate_limit_tokens_and_drops(monkeypatch) -> None:
+    namespace, registry, app = _build_rate_limited_app(monkeypatch, capacity=2, window=30)
+    rate_metrics = build_rate_limit_metrics(namespace, registry=registry)
+    assert rate_metrics.namespace == namespace
+
+    headers = {
+        "Authorization": "Bearer " + "T" * 32,
+        "Idempotency-Key": "idem-ratelimit",
+        "X-Client-ID": "ratelimit-client",
+    }
+
+    first = _send_request(app, url="/api/jobs", json={}, headers=headers)
+    assert first.status_code == 200, {
+        "anchor": _ANCHOR,
+        "status": first.status_code,
+        "body": first.json(),
+    }
+    chain = first.json()["middleware_chain"]
+    assert chain[:3] == _EXPECTED_CHAIN, {"anchor": _ANCHOR, "chain": chain}
+    remaining_header = int(first.headers.get("X-RateLimit-Remaining", "-1"))
+    assert remaining_header == 1, {"anchor": _ANCHOR, "remaining": remaining_header}
+
+    second = _send_request(app, url="/api/jobs", json={}, headers=headers)
+    assert second.status_code == 200, {
+        "anchor": _ANCHOR,
+        "status": second.status_code,
+        "body": second.json(),
+    }
+    assert int(second.headers.get("X-RateLimit-Remaining", "-1")) == 0, {
+        "anchor": _ANCHOR,
+        "headers": dict(second.headers),
+    }
+
+    third = _send_request(app, url="/api/jobs", json={}, headers=headers)
+    assert third.status_code == 429, {
+        "anchor": _ANCHOR,
+        "status": third.status_code,
+        "body": third.json(),
+    }
+
+    gauge_value = registry.get_sample_value(
+        f"{namespace}_ratelimit_tokens",
+        {"route": "/api/jobs"},
+    )
+    drop_value = registry.get_sample_value(
+        f"{namespace}_ratelimit_drops_total",
+        {"route": "/api/jobs"},
+    )
+
+    assert gauge_value == pytest.approx(0.0), {
+        "anchor": _ANCHOR,
+        "gauge": gauge_value,
+        "drops": drop_value,
+    }
+    assert drop_value == pytest.approx(1.0), {"anchor": _ANCHOR, "drops": drop_value}

--- a/tests/retry/test_retry_backoff.py
+++ b/tests/retry/test_retry_backoff.py
@@ -1,41 +1,107 @@
-import math
+"""Retry backoff determinism tests citing AGENTS.md::Determinism."""
 
-from phase6_import_to_sabt.sanitization import deterministic_jitter
-from phase6_import_to_sabt.xlsx.metrics import build_import_export_metrics
-from phase6_import_to_sabt.xlsx.retry import retry_with_backoff
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from src.ops.retry import build_retry_metrics, execute_with_retry
+from tests.conftest import DeterministicClock
+from tests.fixtures.retry import DeterministicBackoffPolicy
+
+_ANCHOR = "AGENTS.md::Determinism"
 
 
-def test_retry_jitter_and_metrics_without_sleep() -> None:
-    metrics = build_import_export_metrics()
-    delays: list[float] = []
-    attempts: list[int] = []
+def _policy_sequence(policy: DeterministicBackoffPolicy, attempts: int) -> list[float]:
+    return [policy.compute(i) for i in range(1, attempts + 1)]
 
-    def sleeper(delay: float) -> None:
-        delays.append(delay)
 
-    def operation(attempt: int) -> str:
-        attempts.append(attempt)
-        if attempt < 3:
-            raise OSError("transient")
+def test_backoff_is_deterministic_per_namespace(clock: DeterministicClock) -> None:
+    namespace = f"retry-{uuid.uuid4().hex}"
+    base_policy = DeterministicBackoffPolicy(operation="phase6.retry", namespace=namespace, route="/ops")
+    first = _policy_sequence(base_policy, 5)
+    again = _policy_sequence(
+        DeterministicBackoffPolicy(operation="phase6.retry", namespace=namespace, route="/ops"),
+        5,
+    )
+    assert first == again, {"anchor": _ANCHOR, "sequence": first}
+
+
+def test_backoff_differs_for_distinct_namespace(clock: DeterministicClock) -> None:
+    policy_a = DeterministicBackoffPolicy(operation="phase6.retry", namespace="ns-a", route="/alloc")
+    policy_b = DeterministicBackoffPolicy(operation="phase6.retry", namespace="ns-b", route="/alloc")
+    assert _policy_sequence(policy_a, 4) != _policy_sequence(policy_b, 4), {
+        "anchor": _ANCHOR,
+        "a": _policy_sequence(policy_a, 4),
+        "b": _policy_sequence(policy_b, 4),
+    }
+
+
+def test_attempt_and_exhaustion_counters(clock: DeterministicClock) -> None:
+    namespace = f"retry-metrics-{uuid.uuid4().hex}"
+    metrics = build_retry_metrics(namespace)
+    policy = DeterministicBackoffPolicy(operation="ops.retry", namespace=namespace, route="/task")
+    attempts: dict[str, int] = {"count": 0}
+
+    def _success_after_two() -> str:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise RuntimeError("unstable")
         return "ok"
 
-    result = retry_with_backoff(
-        operation,
-        attempts=3,
-        base_delay=0.02,
-        seed="fsync_test",
+    result = execute_with_retry(
+        _success_after_two,
+        policy=policy.compute,
+        max_attempts=3,
         metrics=metrics,
-        format_label="xlsx",
-        sleeper=sleeper,
+        clock_tick=lambda seconds: clock.tick(seconds=seconds),
+        operation_name="ops.retry",
     )
+    assert result == "ok", {"anchor": _ANCHOR, "attempts": attempts["count"]}
+    success_value = metrics.registry.get_sample_value(
+        f"{namespace}_retry_attempts_total",
+        {"operation": "ops.retry", "namespace": namespace, "outcome": "success"},
+    )
+    assert success_value == pytest.approx(3.0), {
+        "anchor": _ANCHOR,
+        "success_value": success_value,
+    }
 
-    assert result == "ok"
-    assert attempts == [1, 2, 3]
-    expected_first = deterministic_jitter(0.02, 1, "fsync_test")
-    expected_second = deterministic_jitter(0.02, 2, "fsync_test")
-    assert math.isclose(delays[0], expected_first, rel_tol=0.0, abs_tol=1e-9)
-    assert math.isclose(delays[1], expected_second, rel_tol=0.0, abs_tol=1e-9)
-    retry_metric = metrics.retry_total.labels(operation="fsync_test", format="xlsx")._value.get()
-    assert retry_metric == 2
-    exhaustion_metric = metrics.retry_exhausted_total.labels(operation="fsync_test", format="xlsx")._value.get()
-    assert exhaustion_metric == 0
+    attempts["count"] = 0
+
+    def _always_fail() -> str:
+        attempts["count"] += 1
+        raise RuntimeError("nope")
+
+    with pytest.raises(RuntimeError):
+        execute_with_retry(
+            _always_fail,
+            policy=policy.compute,
+            max_attempts=2,
+            metrics=metrics,
+            clock_tick=lambda seconds: clock.tick(seconds=seconds),
+            operation_name="ops.retry",
+        )
+
+    failure_value = metrics.registry.get_sample_value(
+        f"{namespace}_retry_attempts_total",
+        {"operation": "ops.retry", "namespace": namespace, "outcome": "error"},
+    )
+    exhaustion = metrics.registry.get_sample_value(
+        f"{namespace}_retry_exhaustion_total",
+        {"operation": "ops.retry", "namespace": namespace},
+    )
+    histogram_bucket = metrics.registry.get_sample_value(
+        f"{namespace}_retry_backoff_seconds_bucket",
+        {"operation": "ops.retry", "namespace": namespace, "le": "0.2"},
+    )
+    assert failure_value == pytest.approx(2.0), {
+        "anchor": _ANCHOR,
+        "failure_value": failure_value,
+    }
+    assert exhaustion == pytest.approx(1.0), {"anchor": _ANCHOR, "exhaustion": exhaustion}
+    assert histogram_bucket is not None, {
+        "anchor": _ANCHOR,
+        "bucket": histogram_bucket,
+    }

--- a/tests/security/test_metrics_protection_all_apps.py
+++ b/tests/security/test_metrics_protection_all_apps.py
@@ -1,14 +1,24 @@
 import asyncio
+import json
+from hashlib import blake2s
+from typing import Any, Dict
 
 import httpx
 
 from src.infrastructure.api.routes import create_app as create_infra_app
 from tests.mw.test_middleware_order_all_apps import _build_phase6_app
 
+_ANCHOR = "AGENTS.md::Observability & No PII"
+_HTTP_OK = 200
+_HTTP_UNAUTHORIZED = {401, 403}
+
 
 def _send_request(app, method: str, path: str, **kwargs):
     async def _call():
-        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
             return await client.request(method, path, **kwargs)
 
     return asyncio.run(_call())
@@ -17,17 +27,36 @@ def _send_request(app, method: str, path: str, **kwargs):
 def test_metrics_requires_token_phase6(monkeypatch) -> None:
     app = _build_phase6_app(monkeypatch)
     response = _send_request(app, "GET", "/metrics")
-    assert response.status_code in {401, 403}
+    context: Dict[str, Any] = {
+        "evidence": _ANCHOR,
+        "status": response.status_code,
+        "headers": dict(response.headers),
+    }
+    assert response.status_code in _HTTP_UNAUTHORIZED, json.dumps(context, ensure_ascii=False)
+
     forbidden = _send_request(app, "GET", "/metrics", headers={"X-Metrics-Token": "wrong"})
-    assert forbidden.status_code in {401, 403}
+    context.update({"forbidden": forbidden.status_code})
+    assert forbidden.status_code in _HTTP_UNAUTHORIZED, json.dumps(context, ensure_ascii=False)
+
     ok = _send_request(app, "GET", "/metrics", headers={"X-Metrics-Token": "metrics-token"})
-    assert ok.status_code == 200
+    context.update({"authorized": ok.status_code})
+    assert ok.status_code == _HTTP_OK, json.dumps(context, ensure_ascii=False)
 
 
 def test_metrics_requires_token_infrastructure(monkeypatch) -> None:
-    monkeypatch.setenv("METRICS_TOKEN", "infra-metrics")
+    digest = blake2s(b"infra-metrics", digest_size=6).hexdigest()
+    token = f"infra-{digest}"
+    monkeypatch.setenv("METRICS_TOKEN", token)
     app = create_infra_app()
+
     response = _send_request(app, "GET", "/metrics")
-    assert response.status_code == 401
-    authorized = _send_request(app, "GET", "/metrics", headers={"X-Metrics-Token": "infra-metrics"})
-    assert authorized.status_code == 200
+    context = {
+        "evidence": _ANCHOR,
+        "status": response.status_code,
+        "headers": dict(response.headers),
+    }
+    assert response.status_code in _HTTP_UNAUTHORIZED, json.dumps(context, ensure_ascii=False)
+
+    authorized = _send_request(app, "GET", "/metrics", headers={"X-Metrics-Token": token})
+    context.update({"authorized": authorized.status_code})
+    assert authorized.status_code == _HTTP_OK, json.dumps(context, ensure_ascii=False)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Importable namespace for CI tooling utilities."""
+
+__all__ = [
+    "bom_guard",
+    "strip_bom",
+]

--- a/tools/bom_guard.py
+++ b/tools/bom_guard.py
@@ -1,0 +1,121 @@
+"""Detect UTF-8 BOM markers within the repository tree."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+BOM = "\ufeff".encode("utf-8")
+TARGET_EXTENSIONS: frozenset[str] = frozenset({
+    ".py",
+    ".pyi",
+    ".toml",
+    ".yml",
+    ".yaml",
+    ".ini",
+    ".json",
+})
+SKIP_DIRECTORIES: frozenset[str] = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "build",
+        "dist",
+        "logs",
+        "tmp",
+        "tmpfile",
+        "pip-wheel-metadata",
+    }
+)
+_EVIDENCE = "AGENTS.md::Determinism & CI"
+
+
+@dataclass(slots=True)
+class Finding:
+    """Represents a BOM occurrence for deterministic reporting."""
+
+    path: Path
+    category: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Return a JSON-ready payload describing the BOM finding."""
+        return {"path": str(self.path), "category": self.category, "evidence": _EVIDENCE}
+
+
+def _iter_candidate_files(paths: Sequence[Path]) -> Iterable[Path]:
+    for root in paths:
+        if root.is_file():
+            if root.suffix.lower() in TARGET_EXTENSIONS:
+                yield root
+            continue
+        if root.name in SKIP_DIRECTORIES:
+            continue
+        for candidate in root.iterdir():
+            if candidate.is_symlink():
+                continue
+            if candidate.is_dir() and candidate.name in SKIP_DIRECTORIES:
+                continue
+            if candidate.is_dir():
+                yield from _iter_candidate_files([candidate])
+            elif candidate.is_file() and candidate.suffix.lower() in TARGET_EXTENSIONS:
+                yield candidate
+
+
+def _has_bom(path: Path) -> bool:
+    with path.open("rb") as handle:
+        prefix = handle.read(len(BOM))
+    return prefix == BOM
+
+
+def _collect_findings(paths: Sequence[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for candidate in _iter_candidate_files(paths):
+        if _has_bom(candidate):
+            findings.append(Finding(path=candidate, category="utf8-bom"))
+    return findings
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        type=Path,
+        default=None,
+        help="Optional subset of paths to inspect in addition to the project root.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as a JSON object for machine-readable diagnostics.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Scan the repository tree and fail if a BOM is discovered."""
+    argv = argv or sys.argv[1:]
+    args = _parse_args(argv)
+    root = Path(__file__).resolve().parents[1]
+    targets = [root]
+    if args.paths:
+        targets.extend(args.paths)
+    findings = _collect_findings(targets)
+    if findings:
+        payload = [finding.to_payload() for finding in findings]
+        message = json.dumps({"bom_findings": payload, "evidence": _EVIDENCE}, ensure_ascii=False)
+        if args.json:
+            print(message)
+        else:
+            print(message)
+        return 1
+    if args.json:
+        print(json.dumps({"bom_findings": [], "evidence": _EVIDENCE}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sys.exit(main())

--- a/tools/strip_bom.py
+++ b/tools/strip_bom.py
@@ -1,0 +1,70 @@
+"""Strip UTF-8 BOM markers from provided files deterministically."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+BOM = "\ufeff".encode("utf-8")
+TARGET_EXTENSIONS: frozenset[str] = frozenset({
+    ".py",
+    ".pyi",
+    ".toml",
+    ".yml",
+    ".yaml",
+    ".ini",
+    ".json",
+})
+_EVIDENCE = "AGENTS.md::Determinism & CI"
+
+
+def _ensure_candidates(paths: Sequence[Path]) -> list[Path]:
+    candidates: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            raise FileNotFoundError(path)
+        if path.is_dir():
+            for nested in path.rglob("*"):
+                if nested.is_file() and nested.suffix.lower() in TARGET_EXTENSIONS:
+                    candidates.append(nested)
+            continue
+        if path.suffix.lower() in TARGET_EXTENSIONS:
+            candidates.append(path)
+    return candidates
+
+
+def _strip(path: Path) -> bool:
+    raw = path.read_bytes()
+    if not raw.startswith(BOM):
+        return False
+    path.write_bytes(raw[len(BOM) :])
+    return True
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="Files or directories to clean")
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Remove BOM markers from provided files and report the outcome."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    candidates = _ensure_candidates(args.paths)
+    cleaned = 0
+    for candidate in candidates:
+        if _strip(candidate):
+            cleaned += 1
+    print(
+        {
+            "cleaned": cleaned,
+            "total": len(candidates),
+            "evidence": _EVIDENCE,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add deterministic BOM detection and stripping utilities and expose them through the tools package for CI reuse【F:tools/bom_guard.py†L1-L117】【F:tools/strip_bom.py†L1-L66】【F:tools/__init__.py†L1-L6】
- configure ruff, mypy, and pydocstyle quality gates and wire a GitHub Actions workflow to enforce them alongside the BOM guard and CI suite【F:pyproject.toml†L23-L91】【F:.github/workflows/quality.yml†L1-L67】
- introduce CI fixtures and gating tests that ensure the repository stays BOM-free and quality checks pass deterministically with AGENTS evidence【F:tests/ci/conftest.py†L1-L41】【F:tests/ci/test_bom_guard.py†L1-L34】【F:tests/ci/test_ruff_gate.py†L1-L38】【F:tests/ci/test_mypy_strict.py†L1-L16】【F:tests/ci/test_pydocstyle_gate.py†L1-L37】
- harden middleware, metrics, exporter, and perf regressions with deterministic contexts and AGENTS anchors to prove middleware order, token guards, and perf budgets【F:tests/mw/test_middleware_order_all_apps.py†L1-L162】【F:tests/security/test_metrics_protection_all_apps.py†L1-L62】【F:tests/perf/test_perf_gates.py†L1-L86】【F:tests/export/test_atomic_finalize.py†L1-L38】【F:tests/export/test_xlsx_excel_safety.py†L1-L52】

## Testing
- `python -m ruff check tools/bom_guard.py tools/strip_bom.py tests/ci/conftest.py tests/ci/test_bom_guard.py tests/ci/test_ruff_gate.py tests/ci/test_mypy_strict.py tests/ci/test_pydocstyle_gate.py tests/export/test_xlsx_excel_safety.py tests/export/test_atomic_finalize.py tests/security/test_metrics_protection_all_apps.py tests/mw/test_middleware_order_all_apps.py tests/perf/test_perf_gates.py`【4babc5†L1-L8】
- `python -m pydocstyle tools/bom_guard.py tools/strip_bom.py tests/ci/conftest.py tests/ci/test_bom_guard.py tests/ci/test_ruff_gate.py tests/ci/test_mypy_strict.py tests/ci/test_pydocstyle_gate.py tests/export/test_xlsx_excel_safety.py tests/export/test_atomic_finalize.py tests/security/test_metrics_protection_all_apps.py tests/mw/test_middleware_order_all_apps.py tests/perf/test_perf_gates.py`【7c4ab2†L1-L7】
- `python -m mypy --config-file pyproject.toml`【4ba196†L1-L2】
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -W error tests/ci/test_bom_guard.py tests/ci/test_ruff_gate.py tests/ci/test_mypy_strict.py tests/ci/test_pydocstyle_gate.py tests/export/test_xlsx_excel_safety.py::test_formula_guard_and_sensitive_as_text tests/export/test_atomic_finalize.py::test_part_rename_fsync tests/security/test_metrics_protection_all_apps.py tests/mw/test_middleware_order_all_apps.py tests/perf/test_perf_gates.py`【05f1de†L1-L2】
- `python tools/bom_guard.py --json`【f87b41†L1-L3】

------
https://chatgpt.com/codex/tasks/task_e_68dbd2d5dacc8321b2afecf43da42ceb