### PR TITLE
Fortify ImportToSabt observability and middleware guarantees

### DIFF
--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -11,11 +11,15 @@
 | AGENTS.md::5 Uploads & Exports (Manifests) | tests/exports/test_manifest.py::test_atomic_manifest_after_files |
 | AGENTS.md::5 Uploads & Exports (Atomic I/O) | src/phase6_import_to_sabt/exporter_service.py::atomic_writer |
 | AGENTS.md::6 Observability & Security | tests/security/test_metrics_and_downloads.py::test_token_and_signed_url |
-| AGENTS.md::6 Observability & Security (PII masking) | tests/logging/test_json_logs.py::test_masking_and_correlation_id |
+| AGENTS.md::6 Observability & Security (PII masking) | tests/logging/test_json_logs_pii_scan.py::test_no_pii_in_logs |
+| AGENTS.md::6 Observability & Security (/metrics token) | tests/security/test_metrics_token_guard.py::test_metrics_requires_token |
 | AGENTS.md::7 Performance & Reliability | tests/perf/test_exporter_100k.py::test_p95_latency_and_memory_budget |
 | AGENTS.md::7 Performance & Reliability (Retry) | tests/retry/test_retry_backoff.py::test_retry_jitter_and_metrics_without_sleep |
 | AGENTS.md::8 Testing & CI Gates (State hygiene) | tests/fixtures/state.py::cleanup_fixtures |
+| AGENTS.md::8 Testing & CI Gates (CollectorRegistry reset) | tests/conftest.py::metrics_registry_guard |
+| AGENTS.md::8 Testing & CI Gates (Redis namespace guard) | tests/conftest.py::redis_state_guard |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order) | tests/mw/test_order_uploads.py::test_rate_then_idem_then_auth |
+| AGENTS.md::3 Absolute Guardrails (RateLimit→Idempotency→Auth) | tests/mw/test_order_clocked.py::test_post_chain_order |
 | AGENTS.md::3 Absolute Guardrails (Persian errors) | tests/i18n/test_persian_errors.py::test_error_messages_deterministic |
 | AGENTS.md::4 Domain Rules (Year & Counter) | tests/export/test_crosschecks.py::test_counter_prefix_and_regex |
 | AGENTS.md::4 Domain Rules (StudentType derivation) | src/phase6_import_to_sabt/exporter_service.py::ImportToSabtExporter._normalize_row |

--- a/src/phase6_import_to_sabt/app/app_factory.py
+++ b/src/phase6_import_to_sabt/app/app_factory.py
@@ -131,7 +131,14 @@ def create_application(
         return normalized
 
     service_token = _add_token(config.auth.service_token, "ADMIN")
-    metrics_token = _add_token(config.auth.metrics_token, "METRICS_RO", metrics_only=True)
+    if access and access.metrics_tokens:
+        metrics_token = access.metrics_tokens[0]
+    else:
+        metrics_token = _add_token(
+            config.auth.metrics_token,
+            "METRICS_RO",
+            metrics_only=True,
+        )
 
     if not tokens:
         fallback_token = service_token or "local-service-token"

--- a/src/phase6_import_to_sabt/app/clock.py
+++ b/src/phase6_import_to_sabt/app/clock.py
@@ -1,36 +1,98 @@
 from __future__ import annotations
 
 import datetime as dt
-from dataclasses import dataclass
-from typing import Protocol
-from zoneinfo import ZoneInfo
+import unicodedata
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Protocol, runtime_checkable
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_PERSIAN_DIGIT_MAP = {ord(ch): str(idx) for idx, ch in enumerate("۰۱۲۳۴۵۶۷۸۹")}
+_ARABIC_DIGIT_MAP = {ord(ch): str(idx) for idx, ch in enumerate("٠١٢٣٤٥٦٧٨٩")}
+_ZERO_WIDTH_CHARACTERS = ("\u200c", "\u200d", "\ufeff")
 
 
+@runtime_checkable
 class Clock(Protocol):
     """Protocol describing deterministic clock access."""
 
     def now(self) -> dt.datetime:
-        ...
+        """Return the current :class:`datetime.datetime` (aware when possible)."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FixedClock:
+    """Clock returning a pre-defined instant for deterministic behaviour."""
+
     instant: dt.datetime
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.instant, dt.datetime):  # pragma: no cover - defensive
+            raise TypeError("instant must be a datetime instance")
+
     def now(self) -> dt.datetime:
+        """Return the injected instant as-is."""
+
         return self.instant
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class SystemClock:
+    """Clock backed by :class:`datetime.datetime.now` with an IANA timezone."""
+
     timezone: ZoneInfo
+    _timezone_key: str = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.timezone, ZoneInfo):  # pragma: no cover - defensive
+            raise TypeError("timezone must be a ZoneInfo instance")
+        object.__setattr__(self, "_timezone_key", getattr(self.timezone, "key", str(self.timezone)))
+
+    @property
+    def timezone_name(self) -> str:
+        """Return the canonical timezone key used for logging/debugging."""
+
+        return self._timezone_key
 
     def now(self) -> dt.datetime:
+        """Return the current timezone-aware datetime in the configured zone."""
+
         return dt.datetime.now(tz=self.timezone)
 
 
+def _normalise_timezone_name(timezone: str) -> str:
+    if timezone is None:
+        raise ValueError("منطقهٔ زمانی نامعتبر است؛ مقدار ورودی: None")
+
+    normalized = unicodedata.normalize("NFKC", str(timezone))
+    normalized = normalized.translate(_PERSIAN_DIGIT_MAP).translate(_ARABIC_DIGIT_MAP)
+    for character in _ZERO_WIDTH_CHARACTERS:
+        normalized = normalized.replace(character, "")
+    normalized = normalized.strip()
+
+    if not normalized:
+        raise ValueError("منطقهٔ زمانی نامعتبر است؛ مقدار ورودی خالی است.")
+    if len(normalized) > 255:
+        raise ValueError("منطقهٔ زمانی نامعتبر است؛ طول مقدار بیش از حد مجاز است.")
+
+    return normalized
+
+
+@lru_cache(maxsize=32)
+def _load_zone_info(timezone: str) -> ZoneInfo:
+    return ZoneInfo(timezone)
+
+
 def build_system_clock(timezone: str) -> SystemClock:
-    return SystemClock(timezone=ZoneInfo(timezone))
+    """Build a :class:`SystemClock` for the provided IANA timezone name."""
+
+    normalized = _normalise_timezone_name(timezone)
+    try:
+        zone = _load_zone_info(normalized)
+    except ZoneInfoNotFoundError as exc:  # pragma: no cover - exercised via tests
+        raise ValueError(f"منطقهٔ زمانی نامعتبر است؛ مقدار ورودی: {normalized}.") from exc
+
+    return SystemClock(timezone=zone)
 
 
 __all__ = ["Clock", "FixedClock", "SystemClock", "build_system_clock"]

--- a/src/phase6_import_to_sabt/app/logging_config.py
+++ b/src/phase6_import_to_sabt/app/logging_config.py
@@ -7,7 +7,14 @@ from typing import Any, Dict
 import orjson
 
 
-SENSITIVE_KEYS = {"authorization", "token", "secret"}
+SENSITIVE_KEYS = {
+    "authorization",
+    "token",
+    "secret",
+    "mobile",
+    "national_id",
+    "mentor_id",
+}
 
 
 def _mask_value(value: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Iterator
+from typing import Any, Iterator
+
+from prometheus_client import CollectorRegistry
 
 import pytest
 
@@ -82,6 +86,89 @@ class DeterministicClock:
         self._current = value.astimezone(_TEHRAN_TZ)
         return self._current
 
+
+@dataclass(slots=True)
+class RedisStateContext:
+    client: Any
+    namespace: str
+
+    def key(self, suffix: str) -> str:
+        return f"{self.namespace}:{suffix}"
+
+    def debug(self) -> dict[str, object]:
+        keys = sorted(str(key) for key in self.client.scan_iter(match=f"{self.namespace}:*"))
+        return {"namespace": self.namespace, "keys": keys}
+
+    def purge(self) -> None:
+        _purge_namespace(self.client, self.namespace)
+
+
+def _purge_namespace(client: Any, namespace: str) -> None:
+    pattern = f"{namespace}:*"
+    keys = [str(key) for key in client.scan_iter(match=pattern)]
+    if keys:
+        client.delete(*keys)
+
+
+def _build_redis_client(url: str | None) -> Any:
+    if url:
+        import redis
+
+        return redis.Redis.from_url(url, decode_responses=True)
+    from src.fakeredis import FakeStrictRedis
+
+    return FakeStrictRedis()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def metrics_registry_guard() -> Iterator[CollectorRegistry]:
+    """Reset the Prometheus CollectorRegistry per-module (AGENTS.md §8)."""
+
+    modules_to_patch = (
+        "prometheus_client",
+        "prometheus_client.registry",
+        "prometheus_client.core",
+    )
+    modules = [importlib.import_module(name) for name in modules_to_patch]
+    originals: list[CollectorRegistry | None] = [getattr(module, "REGISTRY", None) for module in modules]
+    new_registry = CollectorRegistry()
+    for module in modules:
+        setattr(module, "REGISTRY", new_registry)
+
+    try:
+        yield new_registry
+    finally:
+        collector_map = getattr(new_registry, "_collector_to_names", {})
+        for collector in list(collector_map.keys()):
+            try:
+                new_registry.unregister(collector)
+            except KeyError:  # pragma: no cover - defensive cleanup
+                continue
+        for module, original in zip(modules, originals):
+            if original is not None:
+                setattr(module, "REGISTRY", original)
+
+
+@pytest.fixture()
+def redis_state_guard() -> Iterator[RedisStateContext]:
+    """Provide isolated Redis namespaces with cleanup before/after (AGENTS.md §8)."""
+
+    url = os.getenv("STRICT_CI_REDIS_URL")
+    namespace = f"import-to-sabt::{uuid.uuid4().hex}"
+    client = _build_redis_client(url)
+    _purge_namespace(client, namespace)
+    context = RedisStateContext(client=client, namespace=namespace)
+    try:
+        yield context
+    finally:
+        context.purge()
+        close = getattr(client, "close", None)
+        if callable(close):  # pragma: no cover - redis-py only
+            close()
+        pool = getattr(client, "connection_pool", None)
+        disconnect = getattr(pool, "disconnect", None)
+        if callable(disconnect):  # pragma: no cover - redis-py only
+            disconnect()
 
 @pytest.fixture()
 def clock() -> Iterator[DeterministicClock]:

--- a/tests/logging/test_json_logs_pii_scan.py
+++ b/tests/logging/test_json_logs_pii_scan.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+from phase6_import_to_sabt.app.logging_config import configure_logging
+
+
+def test_no_pii_in_logs(capfd) -> None:
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    try:
+        configure_logging("import-to-sabt-test", enable_debug=True)
+        logger = logging.getLogger("import.to.sabt")
+        correlation_id = f"cid-{uuid.uuid4().hex}"
+        logger.info(
+            "student.updated",
+            extra={
+                "correlation_id": correlation_id,
+                "mobile": "09123456789",
+                "national_id": "1234567890",
+                "mentor_id": "AB1234567",
+            },
+        )
+        out, _ = capfd.readouterr()
+        lines = [line for line in out.splitlines() if line.strip()]
+        assert lines, "Expected JSON log lines to be emitted"
+        payload = json.loads(lines[-1])
+        debug = {"raw": lines[-1], "payload": payload}
+        assert payload["correlation_id"] == correlation_id, debug
+        assert payload["message"] == "student.updated", debug
+        assert payload["mobile"] != "09123456789", debug
+        assert payload["national_id"] != "1234567890", debug
+        assert payload["mentor_id"] != "AB1234567", debug
+        assert "09123456789" not in lines[-1], debug
+        assert "1234567890" not in lines[-1], debug
+        assert "AB1234567" not in lines[-1], debug
+    finally:
+        root_logger.handlers = original_handlers
+        root_logger.setLevel(original_level)

--- a/tests/mw/test_order_clocked.py
+++ b/tests/mw/test_order_clocked.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import uuid
+from typing import Sequence
+
+import pytest
+
+from tests.phase6_import_to_sabt.access_helpers import access_test_app
+
+
+TOKENS: Sequence[dict[str, object]] = (
+    {"value": "T" * 48, "role": "ADMIN"},
+    {"value": "M" * 48, "role": "METRICS_RO"},
+)
+
+SIGNING_KEYS: Sequence[dict[str, object]] = (
+    {"kid": "abcd", "secret": "S" * 64, "state": "active"},
+)
+
+
+def test_post_chain_order(
+    monkeypatch: pytest.MonkeyPatch,
+    metrics_registry_guard,
+    redis_state_guard,
+) -> None:
+    metrics_namespace = redis_state_guard.namespace.replace(":", "-")
+    with access_test_app(
+        monkeypatch,
+        tokens=TOKENS,
+        signing_keys=SIGNING_KEYS,
+        metrics_namespace=metrics_namespace,
+        registry=metrics_registry_guard,
+    ) as ctx:
+        request_id = f"rid-{uuid.uuid4().hex}"
+        headers = {
+            "Authorization": f"Bearer {TOKENS[0]['value']}",
+            "Idempotency-Key": redis_state_guard.key("jobs"),
+            "X-Client-ID": redis_state_guard.namespace,
+            "X-RateLimit-Key": redis_state_guard.namespace,
+            "X-Request-ID": request_id,
+        }
+        payload = {"job": "import", "attempt": 1}
+        response = ctx.client.post("/api/jobs", json=payload, headers=headers)
+        rate_limit_samples = ctx.metrics.middleware.rate_limit_decision_total.collect()[0].samples
+        idempotency_samples = ctx.metrics.middleware.idempotency_hits_total.collect()[0].samples
+        debug = {
+            "namespace": redis_state_guard.namespace,
+            "redis": redis_state_guard.debug(),
+            "headers": headers,
+            "status": response.status_code,
+            "metrics_samples": {
+                "rate_limit": [sample.labels for sample in rate_limit_samples],
+                "idempotency": [sample.labels for sample in idempotency_samples],
+            },
+        }
+        assert response.status_code == 200, debug
+        body = response.json()
+        debug["body"] = body
+        assert body["correlation_id"] == request_id, debug
+        assert body["middleware_chain"] == ["RateLimit", "Idempotency", "Auth"], debug
+        assert any(sample.labels.get("decision") == "allow" for sample in rate_limit_samples), debug
+        assert any(sample.labels.get("outcome") == "miss" for sample in idempotency_samples), debug

--- a/tests/security/test_metrics_token_guard.py
+++ b/tests/security/test_metrics_token_guard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 from tests.phase6_import_to_sabt.access_helpers import access_test_app
 
 TOKENS = [
@@ -13,23 +15,58 @@ SIGNING_KEYS = [
 ]
 
 
-def test_metrics_requires_token(monkeypatch) -> None:
-    with access_test_app(monkeypatch, tokens=TOKENS, signing_keys=SIGNING_KEYS) as ctx:
+def test_metrics_requires_token(monkeypatch, metrics_registry_guard, redis_state_guard) -> None:
+    metrics_namespace = redis_state_guard.namespace.replace(":", "-")
+    with access_test_app(
+        monkeypatch,
+        tokens=TOKENS,
+        signing_keys=SIGNING_KEYS,
+        metrics_namespace=metrics_namespace,
+        registry=metrics_registry_guard,
+    ) as ctx:
+        missing = ctx.client.get(
+            "/metrics",
+            headers={"X-Request-ID": f"rid-{uuid.uuid4().hex}"},
+        )
+        missing_body = missing.json()
+        debug_missing = {
+            "status": missing.status_code,
+            "body": missing_body,
+            "failures": [sample.labels for sample in ctx.metrics.auth_fail_total.collect()[0].samples],
+        }
+        assert missing.status_code == 401, debug_missing
+        assert missing_body["fa_error_envelope"]["code"] == "UNAUTHORIZED", debug_missing
+
         forbidden = ctx.client.get(
             "/metrics",
-            headers={"Authorization": f"Bearer {TOKENS[0]['value']}"},
+            headers={
+                "Authorization": f"Bearer {TOKENS[0]['value']}",
+                "X-Request-ID": f"rid-{uuid.uuid4().hex}",
+            },
         )
-        assert forbidden.status_code == 403
-        body = forbidden.json()
-        assert body["fa_error_envelope"]["code"] == "METRICS_TOKEN_INVALID"
-
+        forbidden_body = forbidden.json()
         fail_samples = ctx.metrics.auth_fail_total.collect()[0].samples
-        assert any(sample.labels["reason"] == "metrics_forbidden" for sample in fail_samples)
+        debug_forbidden = {
+            "status": forbidden.status_code,
+            "body": forbidden_body,
+            "fail_samples": [sample.labels for sample in fail_samples],
+        }
+        assert forbidden.status_code == 403, debug_forbidden
+        assert forbidden_body["fa_error_envelope"]["code"] == "METRICS_TOKEN_INVALID", debug_forbidden
+        assert any(sample.labels["reason"] == "metrics_forbidden" for sample in fail_samples), debug_forbidden
 
         allowed = ctx.client.get(
             "/metrics",
-            headers={"Authorization": f"Bearer {TOKENS[2]['value']}"},
+            headers={
+                "X-Metrics-Token": TOKENS[2]["value"],
+                "X-Request-ID": f"rid-{uuid.uuid4().hex}",
+            },
         )
-        assert allowed.status_code == 200
+        debug_allowed = {
+            "status": allowed.status_code,
+            "text": allowed.text[:128],
+            "ok_samples": [sample.labels for sample in ctx.metrics.auth_ok_total.collect()[0].samples],
+        }
+        assert allowed.status_code == 200, debug_allowed
         ok_samples = ctx.metrics.auth_ok_total.collect()[0].samples
-        assert any(sample.labels["role"] == "METRICS_RO" for sample in ok_samples)
+        assert any(sample.labels["role"] == "METRICS_RO" for sample in ok_samples), debug_allowed

--- a/tests/time/conftest.py
+++ b/tests/time/conftest.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import hashlib
+import time
+import uuid
+from typing import Any, Callable, Dict, TypeVar
+
+import pytest
+
+T = TypeVar("T")
+
+_STATE_REGISTRY: set[str] = set()
+
+
+def _compute_delay(namespace: str, attempt: int, base_delay: float) -> float:
+    seed = f"{namespace}:{attempt}".encode("utf-8")
+    digest = hashlib.blake2b(seed, digest_size=4).digest()
+    jitter_fraction = int.from_bytes(digest, "big") / 0xFFFFFFFF
+    return base_delay * (2 ** (attempt - 1)) + jitter_fraction * base_delay
+
+
+def _debug_context(namespace: str, attempts: int, delays: tuple[float, ...]) -> Dict[str, Any]:
+    return {
+        "namespace": namespace,
+        "attempts": attempts,
+        "delays": delays,
+        "state_registry": sorted(_STATE_REGISTRY),
+        "middleware_chain": ("RateLimit", "Idempotency", "Auth"),
+        "env": "ci",
+        "timestamp": time.time(),
+    }
+
+
+@pytest.fixture
+def clock_test_context() -> Dict[str, Any]:
+    namespace = f"clock-tests::{uuid.uuid4()}"
+    if namespace in _STATE_REGISTRY:  # pragma: no cover - defensive
+        raise RuntimeError("duplicated namespace detected; state cleanup failed")
+
+    _STATE_REGISTRY.add(namespace)
+    attempts_observed = 0
+    delays: list[float] = []
+    cleanup_log: list[str] = []
+
+    def retry(operation: Callable[[], T], *, max_attempts: int = 3, base_delay: float = 0.01) -> T:
+        nonlocal attempts_observed
+        last_error: Exception | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            attempts_observed = max(attempts_observed, attempt)
+            try:
+                return operation()
+            except Exception as exc:  # pragma: no cover - controlled via caller assertions
+                last_error = exc
+                delays.append(_compute_delay(namespace, attempt, base_delay))
+                if attempt == max_attempts:
+                    debug = _debug_context(namespace, attempts_observed, tuple(delays))
+                    raise AssertionError(f"Operation failed after retries; context={debug}") from exc
+
+        assert last_error is not None  # pragma: no cover - defensive
+        raise last_error
+
+    context: Dict[str, Any] = {
+        "namespace": namespace,
+        "retry": retry,
+        "get_debug_context": lambda: _debug_context(namespace, attempts_observed, tuple(delays)),
+        "cleanup_log": cleanup_log,
+        "middleware_chain": ("RateLimit", "Idempotency", "Auth"),
+    }
+
+    try:
+        yield context
+    finally:
+        cleanup_log.append(f"cleanup::{namespace}")
+        _STATE_REGISTRY.discard(namespace)
+

--- a/tests/time/test_fixed_clock.py
+++ b/tests/time/test_fixed_clock.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from phase6_import_to_sabt.app.clock import FixedClock
+
+
+def test_returns_injected_instant(clock_test_context):
+    reference = dt.datetime(2024, 3, 20, 12, 30, 45, tzinfo=dt.timezone.utc)
+    clock = FixedClock(instant=reference)
+
+    result = clock_test_context["retry"](clock.now)
+
+    assert result is reference or result == reference, (
+        "Injected instant mismatch",
+        clock_test_context["get_debug_context"](),
+    )
+
+
+def test_accepts_naive_datetime(clock_test_context):
+    reference = dt.datetime(2024, 3, 20, 16, 0, 0)
+    clock = FixedClock(instant=reference)
+
+    result = clock_test_context["retry"](clock.now)
+
+    assert result.tzinfo is None, clock_test_context["get_debug_context"]()
+    assert result == reference, clock_test_context["get_debug_context"]()

--- a/tests/time/test_system_clock_tehran.py
+++ b/tests/time/test_system_clock_tehran.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from freezegun import freeze_time
+from zoneinfo import ZoneInfo
+
+from phase6_import_to_sabt.app.clock import build_system_clock
+
+
+def test_now_tz_tehran(clock_test_context):
+    context_debug = clock_test_context["get_debug_context"]
+    with freeze_time("2022-03-21T08:30:00+00:00"):
+        clock = build_system_clock("Asia/Tehran")
+        result = clock_test_context["retry"](clock.now)
+
+    expected = dt.datetime(2022, 3, 21, 12, 0, tzinfo=ZoneInfo("Asia/Tehran"))
+    assert result.tzinfo is not None, context_debug()
+    assert getattr(result.tzinfo, "key", None) == "Asia/Tehran", context_debug()
+    assert result == expected, (result.isoformat(), expected.isoformat(), context_debug())
+    assert clock.timezone_name == "Asia/Tehran", context_debug()
+    assert clock_test_context["middleware_chain"] == ("RateLimit", "Idempotency", "Auth")
+
+
+@pytest.mark.parametrize(
+    "raw_tz, expected_key",
+    [
+        ("  Asia/Tehran\u200c", "Asia/Tehran"),
+    ],
+)
+def test_timezone_normalization(clock_test_context, raw_tz, expected_key):
+    with freeze_time("2023-01-01T00:00:00+00:00"):
+        clock = build_system_clock(raw_tz)
+        result = clock_test_context["retry"](clock.now)
+
+    assert getattr(result.tzinfo, "key", None) == expected_key, clock_test_context["get_debug_context"]()
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [None, "", "0", "Invalid/Zone", "Asia/" + "Tehran" * 60],
+)
+def test_invalid_timezone_raises_persian_error(clock_test_context, invalid):
+    with pytest.raises(ValueError) as excinfo:
+        build_system_clock(invalid)  # type: ignore[arg-type]
+
+    message = str(excinfo.value)
+    assert "منطقهٔ زمانی نامعتبر است" in message, clock_test_context["get_debug_context"]()


### PR DESCRIPTION
## Summary
- add global metrics registry and redis hygiene fixtures to enforce AGENTS.md testing gates
- harden ImportToSabt security by masking PII fields, honoring access-provided metrics tokens, and documenting evidence links
- cover middleware order, metrics token guard, and JSON log masking with deterministic integration tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio tests/mw/test_order_clocked.py tests/security/test_metrics_token_guard.py tests/logging/test_json_logs_pii_scan.py tests/time

------
https://chatgpt.com/codex/tasks/task_e_68dc2e2a8d508321b71b354023d6af9d