### PR TITLE
Inject deterministic clock for ImportToSabt exports

### DIFF
--- a/src/phase6_import_to_sabt/app/clock.py
+++ b/src/phase6_import_to_sabt/app/clock.py
@@ -1,36 +1,19 @@
-from __future__ import annotations
+"""Backward-compatible re-export of clock utilities for application wiring."""
 
-import datetime as dt
-from dataclasses import dataclass
-from typing import Protocol
-from zoneinfo import ZoneInfo
+from ..clock import (
+    CallableClock,
+    Clock,
+    FixedClock,
+    SystemClock,
+    build_system_clock,
+    ensure_clock,
+)
 
-
-class Clock(Protocol):
-    """Protocol describing deterministic clock access."""
-
-    def now(self) -> dt.datetime:
-        ...
-
-
-@dataclass(frozen=True)
-class FixedClock:
-    instant: dt.datetime
-
-    def now(self) -> dt.datetime:
-        return self.instant
-
-
-@dataclass
-class SystemClock:
-    timezone: ZoneInfo
-
-    def now(self) -> dt.datetime:
-        return dt.datetime.now(tz=self.timezone)
-
-
-def build_system_clock(timezone: str) -> SystemClock:
-    return SystemClock(timezone=ZoneInfo(timezone))
-
-
-__all__ = ["Clock", "FixedClock", "SystemClock", "build_system_clock"]
+__all__ = [
+    "Clock",
+    "FixedClock",
+    "SystemClock",
+    "CallableClock",
+    "build_system_clock",
+    "ensure_clock",
+]

--- a/src/phase6_import_to_sabt/clock.py
+++ b/src/phase6_import_to_sabt/clock.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Callable, Protocol, Union
+from zoneinfo import ZoneInfo
+
+
+class Clock(Protocol):
+    """Protocol describing deterministic clock access."""
+
+    def now(self) -> dt.datetime:
+        ...
+
+    def __call__(self) -> dt.datetime:
+        ...
+
+
+@dataclass(frozen=True)
+class FixedClock:
+    instant: dt.datetime
+
+    def now(self) -> dt.datetime:
+        return self.instant
+
+    def __call__(self) -> dt.datetime:
+        return self.now()
+
+
+@dataclass(frozen=True)
+class CallableClock:
+    """Adapter turning a simple callable into a full-featured Clock."""
+
+    delegate: Callable[[], dt.datetime]
+
+    def now(self) -> dt.datetime:
+        value = self.delegate()
+        if not isinstance(value, dt.datetime):  # defensive: avoid subtle bugs in tests
+            raise TypeError(f"Clock delegate returned non-datetime value: {type(value)!r}")
+        return value
+
+    def __call__(self) -> dt.datetime:
+        return self.now()
+
+
+@dataclass
+class SystemClock:
+    timezone: ZoneInfo
+
+    def now(self) -> dt.datetime:
+        return dt.datetime.now(tz=self.timezone)
+
+    def __call__(self) -> dt.datetime:
+        return self.now()
+
+
+def build_system_clock(timezone: str) -> SystemClock:
+    return SystemClock(timezone=ZoneInfo(timezone))
+
+
+def ensure_clock(
+    clock: Union[Clock, Callable[[], dt.datetime], None],
+    *,
+    timezone: str = "Asia/Tehran",
+) -> Clock:
+    """Normalize the provided clock into a full-featured Clock instance."""
+
+    if clock is None:
+        return build_system_clock(timezone)
+    if hasattr(clock, "now") and callable(getattr(clock, "now")):
+        return clock  # type: ignore[return-value]
+    return CallableClock(delegate=clock)
+
+
+__all__ = [
+    "Clock",
+    "FixedClock",
+    "SystemClock",
+    "CallableClock",
+    "build_system_clock",
+    "ensure_clock",
+]

--- a/src/phase6_import_to_sabt/models.py
+++ b/src/phase6_import_to_sabt/models.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from src.shared.counter_rules import COUNTER_PREFIX_MAP
+from .clock import Clock
 
 COUNTER_PREFIX = dict(COUNTER_PREFIX_MAP)
 
@@ -161,9 +162,6 @@ class ExportJob:
     finished_at: Optional[datetime] = None
     manifest: Optional[ExportManifest] = None
     error: Optional[str] = None
-
-
-Clock = Callable[[], datetime]
 
 
 class ExporterDataSource:

--- a/tests/api/test_signed_urls_ttl.py
+++ b/tests/api/test_signed_urls_ttl.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+from urllib.parse import parse_qs, urlparse
+from zoneinfo import ZoneInfo
+
+from phase6_import_to_sabt.api import HMACSignedURLProvider
+from phase6_import_to_sabt.clock import FixedClock
+
+
+def test_signed_url_ttl_is_clock_driven() -> None:
+    frozen = datetime(2024, 1, 1, 8, 0, tzinfo=ZoneInfo("Asia/Tehran"))
+    signer = HMACSignedURLProvider(secret="secret", clock=FixedClock(frozen))
+    signed = signer.sign("/tmp/export.csv", expires_in=900)
+    parsed = urlparse(signed)
+    exp = parse_qs(parsed.query).get("exp", [None])[0]
+    assert exp == str(int(frozen.timestamp()) + 900)
+    assert signer.verify(signed, now=frozen + timedelta(seconds=899))
+    assert not signer.verify(signed, now=frozen + timedelta(seconds=901))

--- a/tests/retry/test_retry_paths.py
+++ b/tests/retry/test_retry_paths.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
+from phase6_import_to_sabt.clock import FixedClock
 from phase6_import_to_sabt.job_runner import ExportJobRunner
 from phase6_import_to_sabt.logging_utils import ExportLogger
 from phase6_import_to_sabt.metrics import ExporterMetrics
@@ -70,7 +71,7 @@ def test_exponential_backoff_and_jitter(tmp_path):
     exporter = FlakyExporter(tmp_path)
     metrics = ExporterMetrics()
     logger = ExportLogger()
-    clock = lambda: datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    clock = FixedClock(datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc))
     delays: list[float] = []
     runner = ExportJobRunner(
         exporter=exporter,

--- a/tests/security/test_metrics_and_downloads.py
+++ b/tests/security/test_metrics_and_downloads.py
@@ -6,6 +6,7 @@ import asyncio
 import httpx
 
 from phase6_import_to_sabt.api import HMACSignedURLProvider, create_export_api
+from phase6_import_to_sabt.clock import FixedClock
 from phase7_release.deploy import ReadinessGate
 from tests.export.helpers import build_job_runner, make_row
 
@@ -22,7 +23,7 @@ def test_token_and_signed_url(tmp_path) -> None:
     rows = [make_row(idx=1)]
     runner, metrics = build_job_runner(tmp_path, rows)
     now = datetime(2024, 1, 1, 8, 0, tzinfo=timezone.utc)
-    signer = HMACSignedURLProvider(secret="secret", clock=lambda: now)
+    signer = HMACSignedURLProvider(secret="secret", clock=FixedClock(now))
     app = create_export_api(
         runner=runner,
         signer=signer,

--- a/tests/time/test_clock_tehran.py
+++ b/tests/time/test_clock_tehran.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+from phase6_import_to_sabt.clock import FixedClock
 from phase6_import_to_sabt.models import ExportFilters, ExportOptions, ExportSnapshot
 
 from tests.export.helpers import build_exporter, build_job_runner, make_row
@@ -23,8 +24,7 @@ def test_clock_freeze_and_naming_determinism(tmp_path):
         assert "20240101080000" in file.name
     assert manifest.generated_at == tehran_now
 
-    clock = lambda: tehran_now
-    runner, metrics = build_job_runner(tmp_path / "runner", rows, clock=clock)
+    runner, metrics = build_job_runner(tmp_path / "runner", rows, clock=FixedClock(tehran_now))
     job = runner.submit(
         filters=ExportFilters(year=1402, center=1),
         options=ExportOptions(output_format="csv"),


### PR DESCRIPTION
## Summary
- introduce a shared clock utility with adapters to wrap callables and provide a default Asia/Tehran system clock
- refactor ImportToSabt signed URL provider and export job runner to rely on the injected clock for deterministic timestamps
- update exporter helpers and integration tests to freeze time and add a signed URL TTL regression test

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/api/test_signed_urls_ttl.py tests/security/test_metrics_and_downloads.py tests/time/test_clock_tehran.py tests/retry/test_retry_paths.py tests/api/test_exports_api.py tests/export/test_crosschecks.py -q


------
https://chatgpt.com/codex/tasks/task_e_68dc375f31f88321bca51af9c10e7799