### PR TITLE
Enforce deterministic clock guard and retry-safe exporter paths

### DIFF
--- a/src/core/clock.py
+++ b/src/core/clock.py
@@ -1,0 +1,110 @@
+"""Unified deterministic clock abstraction for the whole application.
+
+This module is the only place where direct access to the system wall clock is
+permitted. All other modules must inject an instance of :class:`Clock` or use a
+testing double such as :class:`FrozenClock`.
+
+The default timezone is ``Asia/Tehran`` but the implementation supports any
+IANA timezone identifier that can be resolved by :mod:`zoneinfo`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Callable, Protocol
+from zoneinfo import ZoneInfo
+
+
+class SupportsNow(Protocol):
+    """Protocol implemented by objects that expose a ``now`` method."""
+
+    def now(self) -> datetime:
+        """Return the current timezone-aware datetime."""
+
+
+def _system_now() -> datetime:
+    """Return an aware UTC datetime using the system clock."""
+
+    return datetime.now(UTC)
+
+
+@dataclass(slots=True)
+class Clock:
+    """Deterministic clock facade with dependency-injected time source."""
+
+    timezone: ZoneInfo
+    _now_factory: Callable[[], datetime] = _system_now
+
+    def now(self) -> datetime:
+        """Return the current datetime in the configured timezone."""
+
+        current = self._now_factory()
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=UTC)
+        return current.astimezone(self.timezone)
+
+    def isoformat(self) -> str:
+        """Return an ISO formatted string of :meth:`now`."""
+
+        return self.now().isoformat()
+
+    @classmethod
+    def for_timezone(cls, tz_name: str, now_factory: Callable[[], datetime] | None = None) -> "Clock":
+        """Create a clock for the given IANA timezone name."""
+
+        return cls(validate_timezone(tz_name), now_factory or _system_now)
+
+
+@dataclass(slots=True)
+class FrozenClock:
+    """Clock implementation that always returns the frozen value."""
+
+    timezone: ZoneInfo
+    _current: datetime | None = None
+
+    def now(self) -> datetime:
+        if self._current is None:
+            raise RuntimeError("Frozen clock not initialised; call set() first")
+        return self._current
+
+    def set(self, value: datetime) -> None:
+        if value.tzinfo is None:
+            raise ValueError("Frozen clock values must be timezone-aware")
+        self._current = value.astimezone(self.timezone)
+
+    def tick(self, delta_seconds: float) -> None:
+        if self._current is None:
+            raise RuntimeError("Cannot tick before initializing frozen clock")
+        self._current = self._current + timedelta(seconds=delta_seconds)
+
+
+def validate_timezone(tz_name: str) -> ZoneInfo:
+    """Validate and return a :class:`ZoneInfo` instance for *tz_name*."""
+
+    try:
+        return ZoneInfo(tz_name)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        raise ValueError(
+            "CONFIG_TZ_INVALID: «مقدار TIMEZONE نامعتبر است؛ لطفاً یک ناحیهٔ زمانی IANA معتبر وارد کنید.»"
+        ) from exc
+
+
+DEFAULT_TIMEZONE = "Asia/Tehran"
+
+
+def tehran_clock(now_factory: Callable[[], datetime] | None = None) -> Clock:
+    """Return a clock bound to the Tehran timezone."""
+
+    return Clock.for_timezone(DEFAULT_TIMEZONE, now_factory=now_factory)
+
+
+__all__ = [
+    "Clock",
+    "FrozenClock",
+    "SupportsNow",
+    "DEFAULT_TIMEZONE",
+    "tehran_clock",
+    "validate_timezone",
+]
+

--- a/src/core/retry.py
+++ b/src/core/retry.py
@@ -1,0 +1,245 @@
+"""Deterministic retry helpers with metrics instrumentation."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from functools import wraps
+from hashlib import blake2b
+from typing import Any, Awaitable, Callable, Iterable, Protocol, TypeVar
+
+from prometheus_client import Counter, Histogram
+
+from .clock import Clock
+
+T = TypeVar("T")
+
+
+class Sleeper(Protocol):
+    """Protocol for synchronous sleep implementations."""
+
+    def __call__(self, seconds: float) -> None:  # pragma: no cover - protocol
+        ...
+
+
+class AsyncSleeper(Protocol):
+    async def __call__(self, seconds: float) -> None:  # pragma: no cover - protocol
+        ...
+
+
+retry_attempts_total = Counter(
+    "retry_attempts_total",
+    "Total retry attempts per operation and outcome.",
+    labelnames=("op", "outcome"),
+)
+
+retry_exhaustion_total = Counter(
+    "retry_exhaustion_total",
+    "Total number of times retries were exhausted.",
+    labelnames=("op",),
+)
+
+retry_backoff_seconds = Histogram(
+    "retry_backoff_seconds",
+    "Histogram for retry backoff durations in seconds.",
+    labelnames=("op",),
+)
+
+
+@dataclass(slots=True)
+class RetryPolicy:
+    base_delay: float = 0.1
+    factor: float = 2.0
+    max_delay: float = 5.0
+    max_attempts: int = 3
+
+    def backoff_for(self, attempt: int, *, correlation_id: str, op: str) -> float:
+        """Return deterministic backoff including jitter for attempt (1-indexed)."""
+
+        attempt = max(1, attempt)
+        raw = min(self.base_delay * (self.factor ** (attempt - 1)), self.max_delay)
+        digest = blake2b(f"{correlation_id}:{op}:{attempt}".encode("utf-8"), digest_size=2).digest()
+        jitter_seed = int.from_bytes(digest, "big") % 100
+        jitter_multiplier = 1 + jitter_seed / 1000
+        return raw * jitter_multiplier
+
+
+class RetryExhaustedError(RuntimeError):
+    def __init__(self, *, op: str, correlation_id: str, last_error: Exception) -> None:
+        super().__init__(
+            "RETRY_EXHAUSTED: «در حال حاضر امکان انجام عملیات نیست؛ لطفاً بعداً دوباره تلاش کنید.»"
+        )
+        self.op = op
+        self.correlation_id = correlation_id
+        self.last_error = last_error
+
+
+def _should_retry(exception: Exception, retryable: Iterable[type[Exception]]) -> bool:
+    return any(isinstance(exception, exc_type) for exc_type in retryable)
+
+
+def _record_metrics(*, op: str, attempt: int, outcome: str, backoff: float | None) -> None:
+    retry_attempts_total.labels(op=op, outcome=outcome).inc()
+    if backoff is not None:
+        retry_backoff_seconds.labels(op=op).observe(backoff)
+
+
+def execute_with_retry(
+    func: Callable[[], T],
+    *,
+    policy: RetryPolicy,
+    clock: Clock,
+    sleeper: Sleeper,
+    retryable: Iterable[type[Exception]],
+    correlation_id: str,
+    op: str,
+) -> T:
+    last_error: Exception | None = None
+    for attempt in range(1, policy.max_attempts + 1):
+        try:
+            result = func()
+        except Exception as exc:  # pragma: no cover - broad catch required for retry
+            last_error = exc
+            if not _should_retry(exc, retryable) or attempt >= policy.max_attempts:
+                _record_metrics(op=op, attempt=attempt, outcome="failure", backoff=None)
+                retry_exhaustion_total.labels(op=op).inc()
+                raise RetryExhaustedError(op=op, correlation_id=correlation_id, last_error=exc) from exc
+            backoff = policy.backoff_for(attempt, correlation_id=correlation_id, op=op)
+            _record_metrics(op=op, attempt=attempt, outcome="retry", backoff=backoff)
+            sleeper(backoff)
+        else:
+            _record_metrics(op=op, attempt=attempt, outcome="success", backoff=None)
+            return result
+    assert last_error is not None  # pragma: no cover - defensive guard
+    raise RetryExhaustedError(op=op, correlation_id=correlation_id, last_error=last_error)
+
+
+async def execute_with_retry_async(
+    func: Callable[[], Awaitable[T]],
+    *,
+    policy: RetryPolicy,
+    clock: Clock,
+    sleeper: AsyncSleeper,
+    retryable: Iterable[type[Exception]],
+    correlation_id: str,
+    op: str,
+) -> T:
+    last_error: Exception | None = None
+    for attempt in range(1, policy.max_attempts + 1):
+        try:
+            result = await func()
+        except Exception as exc:  # pragma: no cover - see sync version
+            last_error = exc
+            if not _should_retry(exc, retryable) or attempt >= policy.max_attempts:
+                _record_metrics(op=op, attempt=attempt, outcome="failure", backoff=None)
+                retry_exhaustion_total.labels(op=op).inc()
+                raise RetryExhaustedError(op=op, correlation_id=correlation_id, last_error=exc) from exc
+            backoff = policy.backoff_for(attempt, correlation_id=correlation_id, op=op)
+            _record_metrics(op=op, attempt=attempt, outcome="retry", backoff=backoff)
+            await sleeper(backoff)
+        else:
+            _record_metrics(op=op, attempt=attempt, outcome="success", backoff=None)
+            return result
+    assert last_error is not None  # pragma: no cover - defensive guard
+    raise RetryExhaustedError(op=op, correlation_id=correlation_id, last_error=last_error)
+
+
+def build_sync_clock_sleeper(clock: Clock) -> Sleeper:
+    """Return a synchronous sleeper advancing deterministic clocks when possible."""
+
+    def _sleep(seconds: float) -> None:
+        tick = getattr(clock, "tick", None)
+        if callable(tick):  # pragma: no branch - simple guard
+            tick(seconds)  # type: ignore[misc]
+
+    return _sleep
+
+
+def build_async_clock_sleeper(clock: Clock) -> AsyncSleeper:
+    """Return an async sleeper compatible with deterministic retry tests."""
+
+    async def _sleep(seconds: float) -> None:
+        tick = getattr(clock, "tick", None)
+        if callable(tick):  # pragma: no branch - simple guard
+            tick(seconds)  # type: ignore[misc]
+        await asyncio.sleep(0)
+
+    return _sleep
+
+
+def retryable(
+    *,
+    policy: RetryPolicy,
+    clock: Clock,
+    sleeper: Sleeper,
+    retryable_exceptions: Iterable[type[Exception]],
+    op: str,
+    correlation_id_fn: Callable[..., str],
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator for synchronous retry operations."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            correlation_id = correlation_id_fn(*args, **kwargs)
+            return execute_with_retry(
+                lambda: func(*args, **kwargs),
+                policy=policy,
+                clock=clock,
+                sleeper=sleeper,
+                retryable=retryable_exceptions,
+                correlation_id=correlation_id,
+                op=op,
+            )
+
+        return wrapper
+
+    return decorator
+
+
+def retryable_async(
+    *,
+    policy: RetryPolicy,
+    clock: Clock,
+    sleeper: AsyncSleeper,
+    retryable_exceptions: Iterable[type[Exception]],
+    op: str,
+    correlation_id_fn: Callable[..., str],
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Decorator for asynchronous retry operations."""
+
+    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            correlation_id = correlation_id_fn(*args, **kwargs)
+            return await execute_with_retry_async(
+                lambda: func(*args, **kwargs),
+                policy=policy,
+                clock=clock,
+                sleeper=sleeper,
+                retryable=retryable_exceptions,
+                correlation_id=correlation_id,
+                op=op,
+            )
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = [
+    "AsyncSleeper",
+    "Sleeper",
+    "RetryPolicy",
+    "RetryExhaustedError",
+    "execute_with_retry",
+    "execute_with_retry_async",
+    "retryable",
+    "retryable_async",
+    "retry_attempts_total",
+    "retry_exhaustion_total",
+    "retry_backoff_seconds",
+    "build_sync_clock_sleeper",
+    "build_async_clock_sleeper",
+]
+

--- a/src/hardened_api/auth_repository.py
+++ b/src/hardened_api/auth_repository.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, Iterable
+
+from src.core.clock import Clock, tehran_clock
 
 
 @dataclass(slots=True)
@@ -28,14 +30,15 @@ class APIKeyRecord:
 class InMemoryAPIKeyRepository:
     """Simple in-memory repository used for tests and bootstrap."""
 
-    def __init__(self, records: Iterable[APIKeyRecord]) -> None:
+    def __init__(self, records: Iterable[APIKeyRecord], *, clock: Clock | None = None) -> None:
         self._records: Dict[str, APIKeyRecord] = {record.key_hash: record for record in records}
+        self._clock = clock or tehran_clock()
 
     async def is_active(self, hashed_key: str) -> bool:
         record = self._records.get(hashed_key)
         if not record:
             return False
-        now = datetime.now(tz=timezone.utc)
+        now = self._clock.now()
         if record.expires_at and record.expires_at <= now:
             return False
         if record.revoked_at and record.revoked_at <= now:
@@ -45,7 +48,7 @@ class InMemoryAPIKeyRepository:
     async def revoke(self, hashed_key: str) -> None:
         record = self._records.get(hashed_key)
         if record:
-            record.revoked_at = datetime.now(tz=timezone.utc)
+            record.revoked_at = self._clock.now()
 
     def add(self, record: APIKeyRecord) -> None:
         self._records[record.key_hash] = record

--- a/src/phase2_counter_service/cli.py
+++ b/src/phase2_counter_service/cli.py
@@ -9,12 +9,12 @@ import sys
 import time
 import uuid
 from dataclasses import asdict
-from datetime import datetime, timezone
 from importlib import import_module
 from pathlib import Path
 from typing import Iterable, Optional, Sequence
 
 from src.infrastructure.export.excel_safe import make_excel_safe_writer
+from src.core.clock import Clock, tehran_clock
 
 from . import assign_counter, get_config, get_service
 from .backfill import BackfillStats, run_backfill
@@ -32,10 +32,11 @@ PERSIAN_BOOLEAN = {True: "بله", False: "خیر"}
 """Mapping used to localize boolean values for CSV serialization."""
 
 
-def _timestamp_suffix() -> str:
+def _timestamp_suffix(clock: Clock | None = None) -> str:
     """Return an ISO-like timestamp suitable for file names."""
 
-    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    active_clock = clock or tehran_clock()
+    return active_clock.now().strftime("%Y%m%dT%H%M%S")
 
 
 def _ensure_unique_path(path: Path, *, overwrite: bool, original: Optional[str] = None) -> Path:

--- a/src/phase3_allocation/outbox/clock.py
+++ b/src/phase3_allocation/outbox/clock.py
@@ -2,25 +2,29 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
 from typing import Protocol
+
+from src.core.clock import Clock as AppClock, tehran_clock
 
 
 class Clock(Protocol):
     """Clock abstraction for deterministic tests."""
 
-    def now(self) -> datetime:
-        """Return a timezone-aware wall-clock timestamp."""
+    def now(self):  # pragma: no cover - protocol
+        ...
 
-    def monotonic(self) -> float:
-        """Return a monotonic reference in seconds."""
+    def monotonic(self) -> float:  # pragma: no cover - protocol
+        ...
 
 
 class SystemClock(Clock):
     """Default implementation backed by stdlib clocks."""
 
-    def now(self) -> datetime:
-        return datetime.now(timezone.utc)
+    def __init__(self, *, clock: AppClock | None = None) -> None:
+        self._clock = clock or tehran_clock()
+
+    def now(self):
+        return self._clock.now()
 
     def monotonic(self) -> float:
         return time.monotonic()

--- a/src/phase6_import_to_sabt/app/app_factory.py
+++ b/src/phase6_import_to_sabt/app/app_factory.py
@@ -84,6 +84,7 @@ def configure_middleware(app: FastAPI, container: ApplicationContainer) -> None:
         store=container.idempotency_store,
         metrics=container.metrics.middleware,
         timer=container.timer,
+        clock=container.clock,
     )
     app.add_middleware(
         RateLimitMiddleware,

--- a/src/phase6_import_to_sabt/clock.py
+++ b/src/phase6_import_to_sabt/clock.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import datetime as dt
 from dataclasses import dataclass
 from typing import Callable, Protocol, Union
-from zoneinfo import ZoneInfo
+
+import core.clock as core_clock
 
 
 class Clock(Protocol):
@@ -45,17 +46,17 @@ class CallableClock:
 
 @dataclass
 class SystemClock:
-    timezone: ZoneInfo
+    delegate: core_clock.Clock
 
     def now(self) -> dt.datetime:
-        return dt.datetime.now(tz=self.timezone)
+        return self.delegate.now()
 
     def __call__(self) -> dt.datetime:
         return self.now()
 
 
 def build_system_clock(timezone: str) -> SystemClock:
-    return SystemClock(timezone=ZoneInfo(timezone))
+    return SystemClock(delegate=core_clock.Clock.for_timezone(timezone))
 
 
 def ensure_clock(

--- a/src/phase6_import_to_sabt/job_runner.py
+++ b/src/phase6_import_to_sabt/job_runner.py
@@ -167,6 +167,7 @@ class ExportJobRunner:
                     snapshot=job.snapshot,
                     clock_now=start_time,
                     stats=stats,
+                    correlation_id=job.correlation_id,
                 )
                 duration = (self.clock.now() - start_time).total_seconds()
                 self.metrics.observe_duration("total", duration, format_label)

--- a/src/phase6_import_to_sabt/xlsx/workflow.py
+++ b/src/phase6_import_to_sabt/xlsx/workflow.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
 from typing import Callable, Iterable, Optional
-from zoneinfo import ZoneInfo
+import core.clock as core_clock
 
 from phase6_import_to_sabt.sanitization import sanitize_text
 from phase6_import_to_sabt.models import SignedURLProvider
@@ -71,7 +71,7 @@ class ImportToSabtWorkflow:
         self.chunk_size = chunk_size
         self._upload_reader = XLSXUploadReader()
         self._xlsx_writer = XLSXStreamWriter(chunk_size=chunk_size)
-        self._timezone = ZoneInfo("Asia/Tehran")
+        self._timezone = core_clock.validate_timezone("Asia/Tehran")
         self._counter = itertools.count(1)
         self._lock = threading.Lock()
         self._uploads: dict[str, UploadRecord] = {}

--- a/tests/ci/test_state_hygiene.py
+++ b/tests/ci/test_state_hygiene.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from prometheus_client import CollectorRegistry, REGISTRY
+
+from phase6_import_to_sabt.app.clock import FixedClock
+from phase6_import_to_sabt.app.stores import InMemoryKeyValueStore
+from phase6_import_to_sabt.obs.metrics import build_metrics
+
+
+pytestmark = pytest.mark.filterwarnings("ignore::pytest.PytestRemovedIn9Warning")
+
+
+def test_redis_db_tmp_cleaned_and_collector_registry_reset() -> None:
+    baseline = {metric.name for metric in REGISTRY.collect()}
+    registry = CollectorRegistry()
+    metrics = build_metrics("import_to_sabt_state_test", registry=registry)
+    metrics.request_total.labels(method="GET", path="/healthz", status="200").inc()
+    assert {metric.name for metric in REGISTRY.collect()} == baseline
+
+    clock = FixedClock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    store = InMemoryKeyValueStore("state:hygiene", clock)
+
+    async def _exercise() -> None:
+        await store.incr("rate", ttl_seconds=10)
+        await store.delete("rate")
+
+    asyncio.run(_exercise())
+    assert not store._store
+

--- a/tests/ci/test_state_hygiene_retry.py
+++ b/tests/ci/test_state_hygiene_retry.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+from prometheus_client import CollectorRegistry
+
+from core.retry import retry_attempts_total, retry_backoff_seconds, retry_exhaustion_total
+from phase6_import_to_sabt.app.clock import FixedClock
+from phase6_import_to_sabt.app.stores import InMemoryKeyValueStore
+from phase6_import_to_sabt.exporter_service import atomic_writer
+from phase6_import_to_sabt.obs.metrics import build_metrics
+
+
+def test_registry_reset_and_namespaces(tmp_path: Path) -> None:
+    registry = CollectorRegistry()
+    metrics = build_metrics("import_to_sabt_state_retry", registry=registry)
+
+    retry_attempts_total.clear()
+    retry_backoff_seconds.clear()
+    retry_exhaustion_total.clear()
+
+    metrics.retry_attempts_total.labels(operation="ratelimit", route="/api/jobs").inc()
+    metrics.retry_backoff_seconds.labels(operation="ratelimit", route="/api/jobs").observe(0.05)
+    retry_attempts_total.labels(op="phase6.test", outcome="retry").inc()
+    retry_backoff_seconds.labels(op="phase6.test").observe(0.05)
+
+    assert any(sample.value for metric in registry.collect() for sample in metric.samples)
+    metrics.reset()
+    assert all(sample.value == 0 for metric in registry.collect() for sample in metric.samples)
+
+    clock = FixedClock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    store = InMemoryKeyValueStore("state:hygiene", clock)
+
+    async def _exercise() -> None:
+        await store.set("demo", "payload", ttl_seconds=60)
+        await store.delete("demo")
+
+    asyncio.run(_exercise())
+    assert not store._store
+
+    target = tmp_path / "artifact.csv"
+    with atomic_writer(target) as handle:
+        handle.write("value")
+    assert target.exists()
+    assert not list(tmp_path.glob("*.part"))
+
+    retry_attempts_total.clear()
+    retry_backoff_seconds.clear()
+    retry_exhaustion_total.clear()

--- a/tests/config/test_timezone_validation.py
+++ b/tests/config/test_timezone_validation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from phase6_import_to_sabt.app.config import AppConfig
+
+
+def test_invalid_tz_rejected_persian_error() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        AppConfig(
+            redis={"dsn": "redis://localhost:6379/0"},
+            database={"dsn": "postgresql://localhost/import_to_sabt"},
+            auth={
+                "metrics_token": "metrics-token",
+                "service_token": "service-token",
+                "tokens_env_var": "TOKENS",
+                "download_signing_keys_env_var": "DOWNLOAD_KEYS",
+                "download_url_ttl_seconds": 900,
+            },
+            timezone="Asia/Invalid-City",
+        )
+    message = str(excinfo.value)
+    assert "CONFIG_TZ_INVALID" in message
+    assert "مقدار TIMEZONE نامعتبر" in message
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Iterator
+from typing import Dict, Iterator, NamedTuple
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -44,6 +45,8 @@ _ALLOWED_RELATIVE_TESTS: tuple[str, ...] = (
     "tests/excel/test_phase6_atomic_writes.py",
     "tests/domain/test_phase6_counters_rules.py",
     "tests/api/test_phase6_persian_errors.py",
+    "tests/retry/test_retry_jitter_determinism.py",
+    "tests/retry/test_retry_metrics.py",
 )
 
 _ALLOWED_DIRECTORIES = {
@@ -56,6 +59,9 @@ _ALLOWED_DIRECTORIES = {
 _DEFAULT_TZ = ZoneInfo("Asia/Tehran")
 _DEFAULT_START = datetime(2024, 1, 1, 0, 0, tzinfo=_DEFAULT_TZ)
 _ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _ROOT / "src"
+_CLOCK_ALLOWLIST = {(_SRC_ROOT / "core" / "clock.py").resolve()}
+_SCAN_DIRECTORIES = [(_SRC_ROOT / "phase6_import_to_sabt").resolve()]
 
 
 class DeterministicClock:
@@ -108,8 +114,9 @@ def _normalize(path: object) -> str:
     return os.path.relpath(str(path), _ROOT)
 
 
-def pytest_ignore_collect(path, config):  # type: ignore[no-untyped-def]
+def pytest_ignore_collect(collection_path, config):  # type: ignore[no-untyped-def]
     del config  # unused
+    path = Path(collection_path)
     normalized = str(path).replace("\\", "/")
     if any(segment in normalized for segment in _IGNORED_SEGMENTS):
         return True
@@ -130,7 +137,14 @@ def pytest_ignore_collect(path, config):  # type: ignore[no-untyped-def]
     return rel_posix not in _ALLOWED_RELATIVE_TESTS
 
 
-def pytest_sessionstart(session):  # type: ignore[no-untyped-def]
+class _ImportsSnapshot(NamedTuple):
+    datetime_aliases: frozenset[str]
+    time_aliases: frozenset[str]
+    zoneinfo_module_aliases: frozenset[str]
+    zoneinfo_class_aliases: frozenset[str]
+
+
+def _record_duplicate_sys_path(session) -> None:  # type: ignore[no-untyped-def]
     seen: set[str] = set()
     duplicates: list[str] = []
     for entry in sys.path:
@@ -142,6 +156,112 @@ def pytest_sessionstart(session):  # type: ignore[no-untyped-def]
         else:
             seen.add(normalized)
     session.config._phase6_duplicate_sys_path = tuple(duplicates)  # type: ignore[attr-defined]
+
+
+def _collect_time_aliases(tree: ast.AST) -> _ImportsSnapshot:
+    datetime_aliases: set[str] = {"datetime"}
+    time_aliases: set[str] = {"time"}
+    zoneinfo_module_aliases: set[str] = {"zoneinfo"}
+    zoneinfo_class_aliases: set[str] = set()
+
+    for node in getattr(tree, "body", []):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "datetime":
+                for alias in node.names:
+                    if alias.name == "datetime":
+                        datetime_aliases.add(alias.asname or alias.name)
+            elif module == "time":
+                for alias in node.names:
+                    if alias.name == "time":
+                        time_aliases.add(alias.asname or alias.name)
+            elif module == "zoneinfo":
+                for alias in node.names:
+                    if alias.name == "ZoneInfo":
+                        zoneinfo_class_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                target = alias.asname or alias.name
+                if alias.name == "datetime":
+                    datetime_aliases.add(target)
+                elif alias.name == "time":
+                    time_aliases.add(target)
+                elif alias.name == "zoneinfo":
+                    zoneinfo_module_aliases.add(target)
+
+    return _ImportsSnapshot(
+        datetime_aliases=frozenset(datetime_aliases),
+        time_aliases=frozenset(time_aliases),
+        zoneinfo_module_aliases=frozenset(zoneinfo_module_aliases),
+        zoneinfo_class_aliases=frozenset(zoneinfo_class_aliases),
+    )
+
+
+def _resolve_dotted_name(node: ast.AST) -> str | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _detect_wall_clock_usage(path: Path, tree: ast.AST, snapshot: _ImportsSnapshot) -> list[str]:
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            dotted = _resolve_dotted_name(func)
+            if dotted is not None:
+                head, _, attr = dotted.partition(".")
+                if attr in {"now", "utcnow", "today"} and head in snapshot.datetime_aliases:
+                    violations.append(f"{path}:{node.lineno}:{dotted}")
+                elif attr == "time" and head in snapshot.time_aliases:
+                    violations.append(f"{path}:{node.lineno}:{dotted}")
+                elif attr == "ZoneInfo" and head in snapshot.zoneinfo_module_aliases:
+                    violations.append(f"{path}:{node.lineno}:{dotted}")
+            if isinstance(func, ast.Name) and func.id in snapshot.zoneinfo_class_aliases:
+                violations.append(f"{path}:{node.lineno}:{func.id}")
+    return violations
+
+
+def _run_wall_clock_guard() -> Dict[str, tuple[str, ...]]:
+    scanned: list[str] = []
+    failures: list[str] = []
+    if not _SRC_ROOT.exists():
+        return {"scanned": tuple(), "banned": tuple()}
+    for base in _SCAN_DIRECTORIES:
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            resolved = path.resolve()
+            if resolved in _CLOCK_ALLOWLIST:
+                continue
+            scanned.append(str(path))
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError as exc:  # pragma: no cover - invalid sources should not occur
+                failures.append(f"{path}:{exc.lineno}:syntax-error")
+                continue
+            snapshot = _collect_time_aliases(tree)
+            failures.extend(_detect_wall_clock_usage(path, tree, snapshot))
+    return {"scanned": tuple(scanned), "banned": tuple(sorted(failures))}
+
+
+def pytest_sessionstart(session):  # type: ignore[no-untyped-def]
+    _record_duplicate_sys_path(session)
+    guard_payload = _run_wall_clock_guard()
+    session.config._repo_wall_clock_guard = guard_payload  # type: ignore[attr-defined]
+    banned = guard_payload.get("banned", ())
+    if banned:
+        message = (
+            "TIME_SOURCE_FORBIDDEN: «استفادهٔ مستقیم از زمان سیستم مجاز نیست؛ از Clock تزریق‌شده استفاده کنید.» "
+            + ", ".join(banned)
+        )
+        raise pytest.UsageError(message)
 
 
 __all__ = ["DeterministicClock", "clock"]

--- a/tests/exports/test_filename_tehran_clock.py
+++ b/tests/exports/test_filename_tehran_clock.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from phase6_import_to_sabt.exporter_service import ImportToSabtExporter
+from phase6_import_to_sabt.models import (
+    ExportFilters,
+    ExportManifest,
+    ExportOptions,
+    ExportSnapshot,
+    NormalizedStudentRow,
+    SpecialSchoolsRoster,
+    ExporterDataSource,
+    SABT_V1_PROFILE,
+)
+
+
+class _FakeRoster(SpecialSchoolsRoster):
+    def is_special(self, year: int, school_code: int | None) -> bool:  # pragma: no cover - trivial
+        return False
+
+
+class _SingleRowSource(ExporterDataSource):
+    def __init__(self, row: NormalizedStudentRow) -> None:
+        self._row = row
+
+    def fetch_rows(self, filters: ExportFilters, snapshot: ExportSnapshot):  # type: ignore[override]
+        yield self._row
+
+
+def _row_factory(clock_now: datetime) -> NormalizedStudentRow:
+    aware_now = clock_now.astimezone(ZoneInfo("Asia/Tehran"))
+    return NormalizedStudentRow(
+        national_id="0011223344",
+        counter="243733210",
+        first_name="علی",
+        last_name="رضایی",
+        gender=0,
+        mobile="09012345678",
+        reg_center=1,
+        reg_status=1,
+        group_code=101,
+        student_type=0,
+        school_code=123456,
+        mentor_id="m-001",
+        mentor_name="خانم راهنما",
+        mentor_mobile="09120000000",
+        allocation_date=aware_now,
+        year_code="1402",
+        created_at=aware_now,
+        id=1,
+    )
+
+
+@pytest.fixture()
+def exporter(tmp_path: Path) -> ImportToSabtExporter:
+    tz = ZoneInfo("Asia/Tehran")
+    frozen = datetime(2024, 3, 20, 10, 15, 30, tzinfo=tz)
+    row = _row_factory(frozen)
+    source = _SingleRowSource(row)
+    roster = _FakeRoster()
+    exporter = ImportToSabtExporter(
+        data_source=source,
+        roster=roster,
+        output_dir=tmp_path,
+        profile=SABT_V1_PROFILE,
+    )
+    exporter._duration_clock = lambda: 0.0  # type: ignore[attr-defined]
+    return exporter
+
+
+def test_export_filename_uses_frozen_time(exporter: ImportToSabtExporter, tmp_path: Path) -> None:
+    tz = ZoneInfo("Asia/Tehran")
+    frozen = datetime(2024, 3, 20, 10, 15, 30, tzinfo=tz)
+    manifest = exporter.run(
+        filters=ExportFilters(year=1402, center=None),
+        options=ExportOptions(output_format="xlsx"),
+        snapshot=ExportSnapshot(marker="snapshot", created_at=frozen),
+        clock_now=frozen,
+    )
+    assert isinstance(manifest, ExportManifest)
+    files = list(manifest.files)
+    assert files, "manifest must include at least one export artifact"
+    assert files[0].name.startswith("export_SABT_V1_1402-ALL_20240320101530"), files[0].name
+    assert files[0].name.endswith(".xlsx"), files[0].name
+

--- a/tests/exports/test_manifest_tehran_clock.py
+++ b/tests/exports/test_manifest_tehran_clock.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from phase6_import_to_sabt.exporter_service import ImportToSabtExporter
+from phase6_import_to_sabt.models import (
+    ExportFilters,
+    ExportManifest,
+    ExportOptions,
+    ExportSnapshot,
+    NormalizedStudentRow,
+    SpecialSchoolsRoster,
+    ExporterDataSource,
+    SABT_V1_PROFILE,
+)
+
+
+class _ManifestRoster(SpecialSchoolsRoster):
+    def is_special(self, year: int, school_code: int | None) -> bool:  # pragma: no cover - deterministic
+        return bool(school_code and school_code % 2 == 0)
+
+
+class _ManifestSource(ExporterDataSource):
+    def __init__(self, rows: list[NormalizedStudentRow]) -> None:
+        self._rows = rows
+
+    def fetch_rows(self, filters: ExportFilters, snapshot: ExportSnapshot):  # type: ignore[override]
+        yield from self._rows
+
+
+def _build_rows(now: datetime) -> list[NormalizedStudentRow]:
+    tz = ZoneInfo("Asia/Tehran")
+    aware = now.astimezone(tz)
+    return [
+        NormalizedStudentRow(
+            national_id="2233445566",
+            counter="243733211",
+            first_name="زهرا",
+            last_name="احمدی",
+            gender=0,
+            mobile="09012345679",
+            reg_center=2,
+            reg_status=1,
+            group_code=202,
+            student_type=0,
+            school_code=654321,
+            mentor_id="m-777",
+            mentor_name="خانم مربی",
+            mentor_mobile="09120000001",
+            allocation_date=aware,
+            year_code="1402",
+            created_at=aware,
+            id=2,
+        )
+    ]
+
+
+def test_export_manifest_uses_injected_tehran_clock(tmp_path: Path) -> None:
+    tz = ZoneInfo("Asia/Tehran")
+    frozen = datetime(2024, 3, 20, 21, 45, 5, tzinfo=tz)
+    rows = _build_rows(frozen)
+    source = _ManifestSource(rows)
+    roster = _ManifestRoster()
+    exporter = ImportToSabtExporter(
+        data_source=source,
+        roster=roster,
+        output_dir=tmp_path,
+        profile=SABT_V1_PROFILE,
+    )
+    manifest = exporter.run(
+        filters=ExportFilters(year=1402, center=1),
+        options=ExportOptions(output_format="csv"),
+        snapshot=ExportSnapshot(marker="snapshot", created_at=frozen),
+        clock_now=frozen,
+    )
+    assert isinstance(manifest, ExportManifest)
+    assert manifest.generated_at == frozen
+    manifest_path = tmp_path / "export_manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["generated_at"] == frozen.isoformat()
+    assert payload["metadata"]["timestamp"] == frozen.strftime("%Y%m%d%H%M%S")
+    assert payload["filters"]["year"] == 1402
+    assert payload["filters"]["center"] == 1
+

--- a/tests/exports/test_retry_atomic_finalize.py
+++ b/tests/exports/test_retry_atomic_finalize.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from core.retry import RetryPolicy
+from phase6_import_to_sabt.exporter_service import ImportToSabtExporter, atomic_writer
+from phase6_import_to_sabt.models import (
+    ExportFilters,
+    ExportManifest,
+    ExportOptions,
+    ExportSnapshot,
+    ExporterDataSource,
+    NormalizedStudentRow,
+    SABT_V1_PROFILE,
+    SpecialSchoolsRoster,
+)
+
+
+class _Roster(SpecialSchoolsRoster):
+    def is_special(self, year: int, school_code: int | None) -> bool:  # pragma: no cover - deterministic fake
+        return False
+
+
+class _Source(ExporterDataSource):
+    def __init__(self, row: NormalizedStudentRow) -> None:
+        self._row = row
+
+    def fetch_rows(self, filters: ExportFilters, snapshot: ExportSnapshot):  # type: ignore[override]
+        yield self._row
+
+
+def _row(now: datetime) -> NormalizedStudentRow:
+    return NormalizedStudentRow(
+        national_id="0011223344",
+        counter="243733210",
+        first_name="علی",
+        last_name="رضایی",
+        gender=0,
+        mobile="09012345678",
+        reg_center=1,
+        reg_status=1,
+        group_code=101,
+        student_type=0,
+        school_code=123456,
+        mentor_id="m-001",
+        mentor_name="خانم راهنما",
+        mentor_mobile="09120000000",
+        allocation_date=now,
+        year_code="1402",
+        created_at=now,
+        id=1,
+    )
+
+
+def test_finalize_retry_keeps_manifest_consistent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Asia/Tehran")
+    now = datetime(2024, 3, 21, 12, 0, tzinfo=tz)
+    source = _Source(_row(now))
+    roster = _Roster()
+    policy = RetryPolicy(base_delay=0.01, factor=2.0, max_delay=0.05, max_attempts=3)
+    exporter = ImportToSabtExporter(
+        data_source=source,
+        roster=roster,
+        output_dir=tmp_path,
+        profile=SABT_V1_PROFILE,
+        retry_policy=policy,
+    )
+    exporter._duration_clock = lambda: 0.0  # type: ignore[attr-defined]
+
+    state = {"failures": 0}
+    def flaky_atomic_writer(path: Path, *args, **kwargs):
+        ctx = atomic_writer(path, *args, **kwargs)
+
+        class _Wrapper:
+            def __enter__(self):
+                handle = ctx.__enter__()
+                if path.name == "export_manifest.json" and state["failures"] == 0:
+                    state["failures"] += 1
+                    raise OSError("fsync failure")
+                return handle
+
+            def __exit__(self, exc_type, exc, tb):
+                return ctx.__exit__(exc_type, exc, tb)
+
+        return _Wrapper()
+
+    monkeypatch.setattr("phase6_import_to_sabt.exporter_service.atomic_writer", flaky_atomic_writer)
+
+    manifest = exporter.run(
+        filters=ExportFilters(year=1402, center=None),
+        options=ExportOptions(output_format="csv"),
+        snapshot=ExportSnapshot(marker="snapshot", created_at=now),
+        clock_now=now,
+        correlation_id="retry-manifest",
+    )
+
+    assert isinstance(manifest, ExportManifest)
+    assert state["failures"] == 1
+    assert not list(tmp_path.glob("*.part"))
+
+    manifest_path = tmp_path / "export_manifest.json"
+    assert manifest_path.exists()
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["generated_at"] == now.isoformat()
+    assert payload["files"], payload
+
+    first_file = payload["files"][0]
+    artifact_path = tmp_path / first_file["name"]
+    assert artifact_path.exists(), artifact_path
+    digest = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+    assert first_file["sha256"] == digest
+    assert manifest.files[0].sha256 == digest
+    assert manifest.total_rows == first_file["row_count"]

--- a/tests/mw/test_concurrent_idempotency_retry.py
+++ b/tests/mw/test_concurrent_idempotency_retry.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import logging
+
+from core.retry import retry_attempts_total, retry_backoff_seconds, retry_exhaustion_total
+
+from fastapi.testclient import TestClient
+
+from phase6_import_to_sabt.app.app_factory import create_application
+from tests.mw.test_order_retry import FlakyStore, _build_context
+
+
+def test_parallel_posts_single_commit(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    retry_attempts_total.clear()
+    retry_backoff_seconds.clear()
+    retry_exhaustion_total.clear()
+    context = _build_context()
+    unique = context["unique"]
+    clock = context["clock"]
+    rate_store = FlakyStore(f"rate:{unique}", clock, {"incr": 1})
+    idem_store = FlakyStore(f"idem:{unique}", clock, {"set_if_not_exists": 1, "set": 1})
+    app = create_application(
+        config=context["config"],
+        clock=clock,
+        metrics=context["metrics"],
+        timer=context["timer"],
+        rate_limit_store=rate_store,
+        idempotency_store=idem_store,
+        readiness_probes={},
+    )
+    headers = {
+        "Idempotency-Key": f"idem-{unique}",
+        "X-Client-ID": f"client-{unique}",
+        "Authorization": f"Bearer service-{unique}",
+    }
+    with TestClient(app) as client:
+        def _issue() -> tuple[int, dict[str, object]]:
+            response = client.post("/api/jobs", headers=headers, json={})
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {"raw": response.text}
+            return response.status_code, payload
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _: _issue(), range(2)))
+
+        follow_up_status, follow_up_payload = _issue()
+
+    statuses = [status for status, _ in results]
+    payloads = [payload for _, payload in results]
+    success_payloads = [payload for status, payload in results if status == 200]
+    assert statuses.count(200) <= 1, {
+        "statuses": statuses,
+        "payloads": payloads,
+        "rid": "concurrent-idem",
+        "message": "At most one immediate POST should succeed",
+    }
+    assert follow_up_status == 200, {
+        "follow_up_status": follow_up_status,
+        "follow_up_payload": follow_up_payload,
+        "rid": "concurrent-idem",
+    }
+    for payload in success_payloads + [follow_up_payload]:
+        assert payload.get("middleware_chain") == ["RateLimit", "Idempotency", "Auth"], {
+            "payload": payload,
+            "rid": "concurrent-idem",
+        }
+    assert follow_up_payload.get("processed") is True, {
+        "follow_up_payload": follow_up_payload,
+        "rid": "concurrent-idem",
+        "message": "Follow-up POST should return processed confirmation",
+    }
+    assert rate_store.failures["incr"] == 1
+    assert idem_store.failures["set_if_not_exists"] == 1
+    assert idem_store.failures["set"] == 1
+    metrics_ops = {
+        sample.labels.get("op")
+        for metric in retry_attempts_total.collect()
+        for sample in metric.samples
+        if sample.value
+    }
+    assert {"ratelimit.incr", "idempotency.set_if_not_exists", "idempotency.set"}.issubset(metrics_ops)
+    histogram_ops = {
+        sample.labels.get("op")
+        for metric in retry_backoff_seconds.collect()
+        for sample in metric.samples
+        if sample.value
+    }
+    assert histogram_ops, "retry histogram must record deterministic backoff"
+    assert unique not in caplog.text
+    retry_attempts_total.clear()
+    retry_backoff_seconds.clear()
+    retry_exhaustion_total.clear()
+    rate_store._store.clear()
+    idem_store._store.clear()

--- a/tests/mw/test_order_post_exports.py
+++ b/tests/mw/test_order_post_exports.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from phase6_import_to_sabt.app.app_factory import create_application
+from phase6_import_to_sabt.app.clock import FixedClock
+from phase6_import_to_sabt.app.config import AppConfig
+from phase6_import_to_sabt.app.stores import InMemoryKeyValueStore
+from phase6_import_to_sabt.app.timing import DeterministicTimer
+from phase6_import_to_sabt.obs.metrics import build_metrics
+
+
+def _build_context() -> Dict[str, object]:
+    unique = uuid4().hex
+    config = AppConfig(
+        redis={"dsn": "redis://localhost:6379/0", "namespace": f"import_to_sabt_{unique}"},
+        database={"dsn": "postgresql://localhost/import_to_sabt"},
+        auth={
+            "metrics_token": f"metrics-{unique}",
+            "service_token": f"service-{unique}",
+            "tokens_env_var": "TOKENS",
+            "download_signing_keys_env_var": "DOWNLOAD_KEYS",
+            "download_url_ttl_seconds": 900,
+        },
+        timezone="Asia/Tehran",
+    )
+    clock = FixedClock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    timer = DeterministicTimer([0.0, 0.0, 0.0])
+    metrics = build_metrics(f"import_to_sabt_{unique}")
+    return {"config": config, "clock": clock, "timer": timer, "metrics": metrics, "unique": unique}
+
+
+def _assert_order(names: List[str]) -> None:
+    rate_index = names.index("RateLimitMiddleware")
+    idem_index = names.index("IdempotencyMiddleware")
+    auth_index = names.index("AuthMiddleware")
+    assert rate_index < idem_index < auth_index, {
+        "chain": names,
+        "rid": "middleware-order",
+        "message": "Expected RateLimit → Idempotency → Auth order",
+    }
+
+
+def test_middleware_order_respected_post_exports() -> None:
+    context = _build_context()
+    unique = context["unique"]
+    clock = context["clock"]
+    rate_store = InMemoryKeyValueStore(f"rate:{unique}", clock)
+    idem_store = InMemoryKeyValueStore(f"idem:{unique}", clock)
+    app = create_application(
+        config=context["config"],
+        clock=clock,
+        metrics=context["metrics"],
+        timer=context["timer"],
+        rate_limit_store=rate_store,
+        idempotency_store=idem_store,
+        readiness_probes={},
+    )
+    names = [middleware.cls.__name__ for middleware in app.user_middleware]
+    _assert_order(names)
+    headers = {
+        "Idempotency-Key": f"idem-{unique}",
+        "X-Client-ID": f"client-{unique}",
+        "Authorization": f"Bearer service-{unique}",
+    }
+    with TestClient(app) as client:
+        response = client.post("/api/jobs", headers=headers, json={})
+        payload = response.json()
+        assert response.status_code == 200, {
+            "status": response.status_code,
+            "payload": payload,
+            "rid": "middleware-order",
+        }
+        assert payload["middleware_chain"] == ["RateLimit", "Idempotency", "Auth"], {
+            "payload": payload,
+            "rid": "middleware-order",
+        }
+    rate_store._store.clear()
+    idem_store._store.clear()
+

--- a/tests/mw/test_order_retry.py
+++ b/tests/mw/test_order_retry.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Dict, List
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from phase6_import_to_sabt.app.app_factory import create_application
+from phase6_import_to_sabt.app.clock import FixedClock
+from phase6_import_to_sabt.app.config import AppConfig
+from phase6_import_to_sabt.app.stores import InMemoryKeyValueStore
+from phase6_import_to_sabt.app.timing import DeterministicTimer
+from phase6_import_to_sabt.obs.metrics import build_metrics
+
+
+class FlakyStore(InMemoryKeyValueStore):
+    def __init__(self, namespace: str, clock: FixedClock, fail_plan: Dict[str, int] | None = None) -> None:
+        super().__init__(namespace, clock)
+        self._plan = dict(fail_plan or {})
+        self.failures = defaultdict(int)
+
+    async def _maybe_fail(self, op: str) -> None:
+        remaining = self._plan.get(op, 0)
+        if remaining > 0:
+            self._plan[op] = remaining - 1
+            self.failures[op] += 1
+            raise ConnectionError(f"transient-{op}")
+
+    async def incr(self, key: str, ttl_seconds: int) -> int:  # type: ignore[override]
+        await self._maybe_fail("incr")
+        return await super().incr(key, ttl_seconds)
+
+    async def set_if_not_exists(self, key: str, value: str, ttl_seconds: int) -> bool:  # type: ignore[override]
+        await self._maybe_fail("set_if_not_exists")
+        return await super().set_if_not_exists(key, value, ttl_seconds)
+
+    async def set(self, key: str, value: str, ttl_seconds: int) -> None:  # type: ignore[override]
+        await self._maybe_fail("set")
+        await super().set(key, value, ttl_seconds)
+
+
+def _build_context() -> Dict[str, object]:
+    unique = uuid4().hex
+    config = AppConfig(
+        redis={"dsn": "redis://localhost:6379/0", "namespace": f"import_to_sabt_{unique}"},
+        database={"dsn": "postgresql://localhost/import_to_sabt"},
+        auth={
+            "metrics_token": f"metrics-{unique}",
+            "service_token": f"service-{unique}",
+            "tokens_env_var": "TOKENS",
+            "download_signing_keys_env_var": "DOWNLOAD_KEYS",
+            "download_url_ttl_seconds": 900,
+        },
+        timezone="Asia/Tehran",
+    )
+    clock = FixedClock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    timer = DeterministicTimer([0.0, 0.0, 0.0, 0.0])
+    metrics = build_metrics(f"import_to_sabt_{unique}")
+    return {"config": config, "clock": clock, "timer": timer, "metrics": metrics, "unique": unique}
+
+
+def _assert_order(names: List[str]) -> None:
+    rate_index = names.index("RateLimitMiddleware")
+    idem_index = names.index("IdempotencyMiddleware")
+    auth_index = names.index("AuthMiddleware")
+    assert rate_index < idem_index < auth_index, {
+        "chain": names,
+        "rid": "middleware-order-retry",
+        "message": "Expected RateLimit → Idempotency → Auth order",
+    }
+
+
+def test_post_order_with_retry_keeps_sequence() -> None:
+    context = _build_context()
+    unique = context["unique"]
+    clock = context["clock"]
+    rate_store = FlakyStore(f"rate:{unique}", clock, {"incr": 1})
+    idem_store = FlakyStore(f"idem:{unique}", clock, {"set_if_not_exists": 1})
+    app = create_application(
+        config=context["config"],
+        clock=clock,
+        metrics=context["metrics"],
+        timer=context["timer"],
+        rate_limit_store=rate_store,
+        idempotency_store=idem_store,
+        readiness_probes={},
+    )
+    names = [middleware.cls.__name__ for middleware in app.user_middleware]
+    _assert_order(names)
+    headers = {
+        "Idempotency-Key": f"idem-{unique}",
+        "X-Client-ID": f"client-{unique}",
+        "Authorization": f"Bearer service-{unique}",
+    }
+    with TestClient(app) as client:
+        response = client.post("/api/jobs", headers=headers, json={})
+        payload = response.json()
+        assert response.status_code == 200, {
+            "status": response.status_code,
+            "payload": payload,
+            "rid": "middleware-order-retry",
+        }
+        assert payload["middleware_chain"] == ["RateLimit", "Idempotency", "Auth"], payload
+    assert rate_store.failures["incr"] == 1
+    assert idem_store.failures["set_if_not_exists"] == 1
+    rate_store._store.clear()
+    idem_store._store.clear()

--- a/tests/obs/test_metrics_unchanged.py
+++ b/tests/obs/test_metrics_unchanged.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry
+
+from phase6_import_to_sabt.metrics import ExporterMetrics, reset_registry
+
+
+def test_export_metrics_labels_present() -> None:
+    registry = CollectorRegistry()
+    metrics = ExporterMetrics(registry=registry)
+    metrics.inc_job("success", "csv")
+    metrics.observe_duration("write", 0.1, "csv")
+    metrics.observe_rows(25, "csv")
+    metrics.observe_file_bytes(2048, "csv")
+    metrics.inc_error("validation", "csv")
+
+    assert registry.get_sample_value("export_jobs_total", {"status": "success", "format": "csv"}) == 1.0
+    assert registry.get_sample_value("export_duration_seconds_sum", {"phase": "write", "format": "csv"}) == 0.1
+    assert registry.get_sample_value("export_rows_total", {"format": "csv"}) == 25.0
+    assert registry.get_sample_value("export_file_bytes_total", {"format": "csv"}) == 2048.0
+    assert registry.get_sample_value("export_errors_total", {"type": "validation", "format": "csv"}) == 1.0
+
+    reset_registry(registry)
+    for metric in registry.collect():
+        assert not list(metric.samples)
+

--- a/tests/perf/test_export_with_retry_budget.py
+++ b/tests/perf/test_export_with_retry_budget.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from core.clock import FrozenClock
+from core.retry import RetryPolicy
+from phase6_import_to_sabt.exporter_service import ImportToSabtExporter
+from phase6_import_to_sabt.models import (
+    ExportExecutionStats,
+    ExportFilters,
+    ExportManifest,
+    ExportOptions,
+    ExportSnapshot,
+    ExporterDataSource,
+    NormalizedStudentRow,
+    SABT_V1_PROFILE,
+    SpecialSchoolsRoster,
+)
+
+
+class _Roster(SpecialSchoolsRoster):
+    def is_special(self, year: int, school_code: int | None) -> bool:  # pragma: no cover - deterministic fake
+        return False
+
+
+@dataclass
+class _SequenceSource(ExporterDataSource):
+    rows: tuple[NormalizedStudentRow, ...]
+
+    def fetch_rows(self, filters: ExportFilters, snapshot: ExportSnapshot):  # type: ignore[override]
+        yield from self.rows
+
+
+class _DurationClock:
+    def __init__(self, schedule: list[float]) -> None:
+        self._schedule = schedule
+        self._index = 0
+        self._last = 0.0
+
+    def __call__(self) -> float:
+        if self._index < len(self._schedule):
+            self._last = self._schedule[self._index]
+            self._index += 1
+        else:  # pragma: no cover - defensive fallback
+            self._last += 0.01
+        return self._last
+
+
+def _build_rows(tz: ZoneInfo) -> tuple[NormalizedStudentRow, ...]:
+    base = datetime(2024, 4, 1, 8, 0, tzinfo=tz)
+    rows: list[NormalizedStudentRow] = []
+    for index in range(100):
+        aware = base.replace(minute=index % 60)
+        rows.append(
+            NormalizedStudentRow(
+                national_id=f"00{index:08d}",
+                counter=f"24373{index:04d}",
+                first_name="علی",
+                last_name="رضایی",
+                gender=0,
+                mobile="09012345678",
+                reg_center=1,
+                reg_status=1,
+                group_code=101,
+                student_type=0,
+                school_code=123456,
+                mentor_id="m-001",
+                mentor_name="خانم راهنما",
+                mentor_mobile="09120000000",
+                allocation_date=aware,
+                year_code="1402",
+                created_at=aware,
+                id=index + 1,
+            )
+        )
+    return tuple(rows)
+
+
+def test_p95_and_mem_with_overheads(tmp_path: Path) -> None:
+    tz = ZoneInfo("Asia/Tehran")
+    rows = _build_rows(tz)
+    source = _SequenceSource(rows)
+    roster = _Roster()
+    frozen_clock = FrozenClock(timezone=tz)
+    frozen_clock.set(datetime(2024, 4, 1, 8, 0, tzinfo=tz))
+    policy = RetryPolicy(base_delay=0.01, factor=2.0, max_delay=0.05, max_attempts=3)
+    exporter = ImportToSabtExporter(
+        data_source=source,
+        roster=roster,
+        output_dir=tmp_path,
+        profile=SABT_V1_PROFILE,
+        clock=frozen_clock,
+        retry_policy=policy,
+    )
+    durations = _DurationClock([0.0, 0.03, 0.03, 0.08, 0.08, 0.13, 0.13, 0.18])
+    exporter._duration_clock = durations  # type: ignore[attr-defined]
+
+    manifest = exporter.run(
+        filters=ExportFilters(year=1402, center=None),
+        options=ExportOptions(output_format="csv", chunk_size=50),
+        snapshot=ExportSnapshot(marker="snapshot", created_at=frozen_clock.now()),
+        clock_now=frozen_clock.now(),
+        correlation_id="perf-budget",
+    )
+
+    assert isinstance(manifest, ExportManifest)
+    assert manifest.total_rows == len(rows)
+    stats = exporter.last_stats
+    assert isinstance(stats, ExportExecutionStats)
+    for phase, duration in stats.phase_durations.items():
+        assert duration <= 0.2, {"phase": phase, "duration": duration}
+
+    for file in manifest.files:
+        assert file.byte_size < 150 * 1024 * 1024
+
+    assert not list(tmp_path.glob("*.part"))

--- a/tests/retry/test_retry_jitter_determinism.py
+++ b/tests/retry/test_retry_jitter_determinism.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.core.clock import Clock
+from src.core.retry import RetryPolicy
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [1, 2, 3, 4],
+)
+def test_b2_seeded_jitter_stable(attempt: int) -> None:
+    policy = RetryPolicy(base_delay=0.25, factor=2.0, max_delay=10.0, max_attempts=5)
+    delay = policy.backoff_for(attempt, correlation_id="rid-123", op="export")
+    repeat_delay = policy.backoff_for(attempt, correlation_id="rid-123", op="export")
+    assert delay == pytest.approx(repeat_delay), "Jitter must be deterministic"
+
+
+def test_clock_timezone_is_asia_tehran() -> None:
+    clock = Clock.for_timezone("Asia/Tehran")
+    now = clock.now()
+    assert now.tzinfo == ZoneInfo("Asia/Tehran")
+
+
+def test_retry_policy_uses_clock_fixture(clock) -> None:  # type: ignore[no-untyped-def]
+    frozen = Clock.for_timezone("Asia/Tehran", now_factory=clock.now)
+    before = frozen.now()
+    _ = frozen.isoformat()
+    clock.tick(seconds=5)
+    after = frozen.now()
+    assert (after - before).total_seconds() == pytest.approx(5.0)

--- a/tests/retry/test_retry_metrics.py
+++ b/tests/retry/test_retry_metrics.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.core.clock import Clock
+from src.core.retry import (
+    RetryExhaustedError,
+    RetryPolicy,
+    execute_with_retry_async,
+    execute_with_retry,
+    retry_attempts_total,
+    retry_backoff_seconds,
+    retry_exhaustion_total,
+)
+
+
+class Boom(RuntimeError):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    retry_attempts_total.clear()
+    retry_backoff_seconds.clear()
+    retry_exhaustion_total.clear()
+    yield
+    retry_attempts_total.clear()
+    retry_backoff_seconds.clear()
+    retry_exhaustion_total.clear()
+
+
+def test_retry_metrics_labeled(clock) -> None:  # type: ignore[no-untyped-def]
+    clock.tick(seconds=0)
+    policy = RetryPolicy(base_delay=0.1, factor=2.0, max_delay=0.2, max_attempts=2)
+    tehran = Clock.for_timezone("Asia/Tehran", now_factory=clock.now)
+
+    def action() -> str:
+        raise Boom("transient")
+
+    with pytest.raises(RetryExhaustedError):
+        execute_with_retry(
+            action,
+            policy=policy,
+            clock=tehran,
+            sleeper=lambda seconds: clock.tick(seconds=seconds),
+            retryable=(Boom,),
+            correlation_id="rid-1",
+            op="unit-test",
+        )
+
+    counts = retry_attempts_total.collect()[0].samples
+    labels = {sample.labels["outcome"] for sample in counts}
+    assert {"failure", "retry"}.issubset(labels)
+
+
+def test_retry_metrics_async(clock) -> None:  # type: ignore[no-untyped-def]
+    policy = RetryPolicy(base_delay=0.05, factor=2.0, max_delay=0.1, max_attempts=3)
+    tehran = Clock.for_timezone("Asia/Tehran", now_factory=clock.now)
+    attempts: list[int] = []
+
+    async def sleeper(seconds: float) -> None:
+        clock.tick(seconds=seconds)
+
+    async def action() -> str:
+        attempts.append(len(attempts))
+        if len(attempts) < 2:
+            raise Boom("retry me")
+        return "ok"
+
+    result = asyncio.run(
+        execute_with_retry_async(
+            action,
+            policy=policy,
+            clock=tehran,
+            sleeper=sleeper,
+            retryable=(Boom,),
+            correlation_id="rid-2",
+            op="async-test",
+        )
+    )
+
+    assert result == "ok"
+    histogram_samples = retry_backoff_seconds.collect()[0].samples
+    assert histogram_samples, "Backoff histogram should record entries"

--- a/tests/retry/test_retry_persian_exhaustion.py
+++ b/tests/retry/test_retry_persian_exhaustion.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.clock import FrozenClock, tehran_clock
+from core.retry import (
+    RetryExhaustedError,
+    RetryPolicy,
+    build_async_clock_sleeper,
+    build_sync_clock_sleeper,
+    execute_with_retry,
+    execute_with_retry_async,
+)
+
+
+class _Boom(RuntimeError):
+    pass
+
+
+def test_exhaustion_message_deterministic_sync() -> None:
+    clock = tehran_clock()
+    policy = RetryPolicy(base_delay=0.1, factor=2, max_attempts=2)
+
+    def flaky() -> int:
+        raise _Boom("boom")
+
+    sleeper = build_sync_clock_sleeper(clock)
+
+    with pytest.raises(RetryExhaustedError) as excinfo:
+        execute_with_retry(
+            flaky,
+            policy=policy,
+            clock=clock,
+            sleeper=sleeper,
+            retryable=(_Boom,),
+            correlation_id="rid-sync",
+            op="sync-op",
+        )
+
+    assert "RETRY_EXHAUSTED" in str(excinfo.value)
+    assert excinfo.value.correlation_id == "rid-sync"
+    assert isinstance(excinfo.value.last_error, _Boom)
+
+
+def test_exhaustion_message_deterministic_async() -> None:
+    frozen = FrozenClock(timezone=tehran_clock().timezone)
+    now = tehran_clock().now()
+    frozen.set(now)
+    policy = RetryPolicy(base_delay=0.1, factor=2, max_attempts=2)
+
+    async def flaky_async() -> int:
+        raise _Boom("boom")
+
+    sleeper = build_async_clock_sleeper(frozen)
+
+    with pytest.raises(RetryExhaustedError) as excinfo:
+        asyncio.run(
+            execute_with_retry_async(
+                flaky_async,
+                policy=policy,
+                clock=frozen,
+                sleeper=sleeper,
+                retryable=(_Boom,),
+                correlation_id="rid-async",
+                op="async-op",
+            )
+        )
+
+    assert "RETRY_EXHAUSTED" in str(excinfo.value)
+    assert excinfo.value.correlation_id == "rid-async"
+    assert isinstance(excinfo.value.last_error, _Boom)

--- a/tests/time/test_wall_clock_forbidden.py
+++ b/tests/time/test_wall_clock_forbidden.py
@@ -1,0 +1,44 @@
+"""Ensure phase6 ImportToSabt code never touches wall-clock APIs directly."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SERVICE_ROOT = PROJECT_ROOT / "src" / "phase6_import_to_sabt"
+ALLOWLIST = {
+    SERVICE_ROOT / "app" / "clock.py",
+    SERVICE_ROOT / "clock.py",
+}
+TARGET_FILES = tuple(sorted(p for p in SERVICE_ROOT.rglob("*.py") if p not in ALLOWLIST))
+
+
+@pytest.mark.parametrize("path", TARGET_FILES)
+def test_forbidden_wall_clock_calls_in_src(path: Path) -> None:
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    banned: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                target = (func.value.id, func.attr)
+                if target in {("datetime", "now"), ("datetime", "utcnow")}:
+                    banned.append(f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}")
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                if func.value.id == "time" and func.attr == "time":
+                    banned.append(f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}")
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.value.id == "time" and node.attr == "time":
+                if isinstance(getattr(node, "ctx", None), ast.Load):
+                    banned.append(f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}")
+
+    assert not banned, (
+        "TIME_SOURCE_FORBIDDEN: «استفادهٔ مستقیم از زمان سیستم مجاز نیست؛ از Clock تزریق‌شده استفاده کنید.» "
+        + ", ".join(banned)
+    )
+

--- a/tests/time/test_wall_clock_repo_guard.py
+++ b/tests/time/test_wall_clock_repo_guard.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_no_datetime_now_repo_wide(pytestconfig: pytest.Config) -> None:
+    guard_payload = getattr(pytestconfig, "_repo_wall_clock_guard", None)
+    assert guard_payload is not None, "wall clock guard payload missing"
+    banned = guard_payload.get("banned", ())
+    assert not banned, (
+        "TIME_SOURCE_FORBIDDEN: «استفادهٔ مستقیم از زمان سیستم مجاز نیست؛ از Clock تزریق‌شده استفاده کنید.» "
+        + ", ".join(str(item) for item in banned)
+    )
+    scanned = guard_payload.get("scanned", ())
+    assert scanned, "wall clock guard must scan at least one source file"
+    suffixes = {Path(path).suffix for path in scanned}
+    assert suffixes == {".py"}, suffixes


### PR DESCRIPTION
## Summary
- add a phase6 AST guard to prohibit direct wall-clock usage and prove it with the new repo guard test
- integrate deterministic retry handling and manifest cleanup into the ImportToSabt exporter and ensure job runner correlation IDs propagate
- extend integration coverage with retry manifest resilience, metrics token guard, hygiene, concurrency, and performance budget tests

## Testing
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -p pytest_asyncio -c pytest.min.ini tests/time/test_wall_clock_repo_guard.py tests/exports/test_retry_atomic_finalize.py tests/security/test_metrics_token_guard.py tests/ci/test_state_hygiene_retry.py tests/perf/test_export_with_retry_budget.py tests/mw/test_concurrent_idempotency_retry.py

------
https://chatgpt.com/codex/tasks/task_e_68df5ba69dd083218cfc48f137ae9c3f