### PR TITLE
Add strict scoring parser regression test and stabilize middleware coverage

### DIFF
--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -23,6 +23,7 @@
 | AGENTS.md::8 Testing & CI Gates (CollectorRegistry reset) | tests/conftest.py::metrics_registry_guard |
 | AGENTS.md::8 Testing & CI Gates (Redis namespace guard) | tests/conftest.py::redis_state_guard |
 | AGENTS.md::8 Testing & CI Gates (Strict Scoring Parser) | scripts/ci_pytest_summary_parser.py::main |
+| AGENTS.md::8 Testing & CI Gates (Strict Scoring Parser Test) | tests/ci/test_ci_pytest_summary_parser.py::test_strict_scoring_v2_all_axes_and_caps |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order) | tests/mw/test_order_uploads.py::test_rate_then_idem_then_auth |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order POST) | tests/mw/test_order_post.py::test_middleware_order_post_exact |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order GET) | tests/mw/test_order_get.py::test_middleware_order_get_paths |

--- a/tests/ci/test_ci_pytest_summary_parser.py
+++ b/tests/ci/test_ci_pytest_summary_parser.py
@@ -1,0 +1,73 @@
+"""Strict Scoring v2 regression tests for the pytest summary parser."""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from scripts.ci_pytest_summary_parser import compute_scores, parse_summary
+
+
+def test_strict_scoring_v2_all_axes_and_caps() -> None:
+    """Compute scores honour clamps, deductions, and all caps."""
+
+    clean_summary = parse_summary(
+        "===== 128 passed, 0 failed, 0 xfailed, 0 skipped, 0 warnings in 12.34s ====="
+    )
+    axes, total, caps = compute_scores(
+        clean_summary,
+        gui_in_scope=False,
+        perf_deduction=-1.0,
+        excel_deduction=5.5,
+        gui_deduction=0.0,
+        sec_deduction=1.0,
+        next_actions_pending=False,
+        missing_deps=False,
+        skips_justified=True,
+    )
+
+    assert not caps
+    assert pytest.approx(sum(axis.clamped for axis in axes), rel=1e-6) == total
+    perf_axis = axes[0]
+    assert perf_axis.label == "Performance & Core"
+    assert perf_axis.clamped == perf_axis.max_value == 49.0
+    excel_axis = axes[1]
+    assert excel_axis.clamped == pytest.approx(40.5)
+    sec_axis = axes[3]
+    assert sec_axis.clamped == pytest.approx(4.0)
+    assert total == pytest.approx(93.5)
+
+    capped_summary = parse_summary(
+        "===== 20 passed, 0 failed, 1 xfailed, 2 skipped, 3 warnings in 1.23s ====="
+    )
+    capped_axes, capped_total, caps_applied = compute_scores(
+        capped_summary,
+        gui_in_scope=True,
+        perf_deduction=0.0,
+        excel_deduction=0.0,
+        gui_deduction=2.5,
+        sec_deduction=0.0,
+        next_actions_pending=True,
+        missing_deps=True,
+        skips_justified=False,
+    )
+
+    assert capped_total <= 85.0
+    assert {axis.label for axis in capped_axes} == {
+        "Performance & Core",
+        "Persian Excel",
+        "GUI",
+        "Security",
+    }
+    assert caps_applied == [
+        "warnings>0 → cap=90",
+        "skipped/xfailed → cap=92",
+        "next_actions pending → cap=95",
+        "missing dependencies → cap=85",
+        "service skip hard cap <90",
+    ]
+    assert math.isclose(
+        capped_total,
+        min(sum(axis.clamped for axis in capped_axes), 85.0),
+        rel_tol=1e-6,
+    )

--- a/tests/hardened_api/conftest.py
+++ b/tests/hardened_api/conftest.py
@@ -1,5 +1,4 @@
 import asyncio
-import asyncio
 import json
 import time
 import uuid

--- a/tests/mw/test_order_post.py
+++ b/tests/mw/test_order_post.py
@@ -14,7 +14,7 @@ async def test_middleware_order_post_exact(client, clean_state):
     payload = setup_test_data(suffix)
     headers = {
         "Authorization": "Bearer TESTTOKEN1234567890",
-        "Idempotency-Key": f"idem:test:{uuid.uuid4().hex[:12]}",
+        "Idempotency-Key": f"idem-test-{uuid.uuid4().hex[:12]}",
         "X-Debug-MW-Probe": "trace",
         "Content-Type": "application/json; charset=utf-8",
     }


### PR DESCRIPTION
## Summary
- add a dedicated Strict Scoring v2 regression test that exercises clamp logic, deductions, and every cap path
- update the middleware order POST test to use a spec-compliant idempotency token and tidy the shared fixture import
- extend the evidence map with the new CI gate evidence entry

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/ci/test_ci_pytest_summary_parser.py -q -p pytest_asyncio
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/perf/test_http_p95_concurrency_200.py -q -p pytest_asyncio -o asyncio_default_fixture_loop_scope=function
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/exports/test_csv_bom_crlf.py -q -p pytest_asyncio -o asyncio_default_fixture_loop_scope=function
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/exports/test_xlsx_safety.py -q -p pytest_asyncio -o asyncio_default_fixture_loop_scope=function
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/obs/test_retry_histogram.py -q -p pytest_asyncio -o asyncio_default_fixture_loop_scope=function
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/mw/test_order_post.py -q -p pytest_asyncio -o asyncio_default_fixture_loop_scope=function
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini tests/mw/test_order_get.py -q -p pytest_asyncio -o asyncio_default_fixture_loop_scope=function

------
https://chatgpt.com/codex/tasks/task_e_68df97e66ed4832185891ff33f1dd5d2