### PR TITLE
Refactor clocks to enforce Asia/Tehran determinism

### DIFF
--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -17,15 +17,19 @@
 | AGENTS.md::6 Observability & Security (/metrics token) | tests/security/test_metrics_token_guard.py::test_metrics_requires_token |
 | AGENTS.md::7 Performance & Reliability | tests/perf/test_export_100k_perf.py::test_p95_latency_and_memory_budget |
 | AGENTS.md::7 Performance & Reliability (Retry) | tests/retry/test_retry_backoff.py::test_retry_jitter_and_metrics_without_sleep |
+| AGENTS.md::7 Performance & Reliability (Exporter retry integration) | tests/exports/test_job_runner_retry_metrics.py::test_export_job_runner_retry_deterministic_backoff |
+| AGENTS.md::7 Performance & Reliability (Retry exhaustion metrics) | tests/exports/test_job_runner_retry_metrics.py::test_export_job_runner_retry_exhaustion_records_failure_metrics |
 | AGENTS.md::8 Testing & CI Gates (State hygiene) | tests/fixtures/state.py::cleanup_fixtures |
 | AGENTS.md::8 Testing & CI Gates (CollectorRegistry reset) | tests/conftest.py::metrics_registry_guard |
 | AGENTS.md::8 Testing & CI Gates (Redis namespace guard) | tests/conftest.py::redis_state_guard |
 | AGENTS.md::8 Testing & CI Gates (Strict Scoring Parser) | scripts/ci_pytest_summary_parser.py::main |
 | AGENTS.md::8 Testing & CI Gates (Strict Scoring Parser Test) | tests/ci/test_ci_pytest_summary_parser.py::test_strict_scoring_v2_all_axes_and_caps |
+| AGENTS.md::8 Testing & CI Gates (Export retry hygiene) | tests/exports/test_job_runner_retry_metrics.py::test_export_job_runner_retry_exhaustion_records_failure_metrics |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order) | tests/mw/test_order_uploads.py::test_rate_then_idem_then_auth |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order POST) | tests/mw/test_order_post.py::test_middleware_order_post_exports_xlsx |
 | AGENTS.md::3 Absolute Guardrails (Middleware Order GET) | tests/mw/test_order_get.py::test_middleware_order_get_paths |
 | AGENTS.md::3 Absolute Guardrails (RateLimit→Idempotency→Auth) | tests/mw/test_order_clocked.py::test_post_chain_order |
+| AGENTS.md::3 Absolute Guardrails (Diagnostics chain proof) | tests/mw/test_middleware_diagnostics_chain.py::test_middleware_chain_recorded_rate_limit_idem_auth |
 | AGENTS.md::3 Absolute Guardrails (Idempotency concurrency) | tests/idem/test_concurrent_posts.py::test_only_one_succeeds |
 | AGENTS.md::3 Absolute Guardrails (Rate limit Persian errors) | tests/ratelimit/test_limits.py::test_exceed_limit_persian_error |
 | AGENTS.md::3 Absolute Guardrails (Persian errors) | tests/i18n/test_persian_errors.py::test_export_validation_error_message_exact |

--- a/ops/audit_review.py
+++ b/ops/audit_review.py
@@ -87,7 +87,7 @@ async def _build_service(dsn: str) -> tuple[AuditService, ReleaseManifest]:
 def service_tz():
     from zoneinfo import ZoneInfo
 
-    return ZoneInfo("Asia/Baku")
+    return ZoneInfo("Asia/Tehran")
 
 
 async def _main(dsn: str = DEFAULT_DSN) -> None:

--- a/src/ci_orchestrator/orchestrator.py
+++ b/src/ci_orchestrator/orchestrator.py
@@ -20,6 +20,8 @@ from prometheus_client import CollectorRegistry, Counter, generate_latest
 from starlette.responses import PlainTextResponse
 from zoneinfo import ZoneInfo
 
+from src.core.clock import tehran_clock
+
 ARTIFACT_DIR = pathlib.Path("artifacts")
 LAST_CMD_ARTIFACT = ARTIFACT_DIR / "last_cmd.txt"
 WARNINGS_ARTIFACT = ARTIFACT_DIR / "ci_warnings_report.json"
@@ -141,7 +143,7 @@ class Orchestrator:
 
     def _default_clock(self) -> dt.datetime:
         tz = ZoneInfo(self.config.timezone)
-        return dt.datetime.now(tz)
+        return tehran_clock().now().astimezone(tz)
 
     def _derive_correlation_id(self) -> str:
         return (

--- a/src/core/datetime_utils.py
+++ b/src/core/datetime_utils.py
@@ -1,13 +1,15 @@
 """ابزارهای زمانی برای استفاده سراسری با آگاهی از منطقه زمانی."""
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC
+
+from src.core.clock import tehran_clock
 
 
 def utc_now() -> datetime:
     """Return timezone-aware UTC timestamp compliant with Python 3.11 APIs."""
 
-    return datetime.now(UTC)
+    return tehran_clock().now().astimezone(UTC)
 
 
 __all__ = ["utc_now"]

--- a/src/domain/shared/events.py
+++ b/src/domain/shared/events.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Sequence
 from uuid import UUID, uuid4
 
+from src.core.clock import tehran_clock
+
+_CLOCK = tehran_clock()
 
 @dataclass(slots=True)
 class DomainEvent:
@@ -27,7 +30,7 @@ class DomainEvent:
             event_id=uuid4(),
             event_type=event_type,
             version=version,
-            occurred_at=datetime.now(timezone.utc),
+            occurred_at=_CLOCK.now(),
             correlation_id=correlation_id,
             causation_id=causation_id,
             tenant=tenant,

--- a/src/ops/config.py
+++ b/src/ops/config.py
@@ -30,7 +30,7 @@ class OpsSettings(BaseSettings):
     reporting_replica_dsn: PostgresDsn = Field(..., alias="REPORTING_REPLICA_DSN")
     metrics_read_token: str = Field(..., min_length=16, alias="METRICS_READ_TOKEN")
     slo_thresholds: SLOThresholds
-    timezone: str = Field("Asia/Baku", alias="OPS_TIMEZONE")
+    timezone: str = Field("Asia/Tehran", alias="OPS_TIMEZONE")
 
     @field_validator("metrics_read_token")
     @classmethod

--- a/src/phase7_release/release_builder.py
+++ b/src/phase7_release/release_builder.py
@@ -22,13 +22,13 @@ from .perf_harness import PerfBaseline, PerfHarness
 from .sbom import generate_sbom
 from .versioning import resolve_build_version
 
-_BAKU_TZ = ZoneInfo("Asia/Baku")
+_TEHRAN_TZ = ZoneInfo("Asia/Tehran")
 
 
-def _ensure_baku(dt: datetime) -> datetime:
+def _ensure_tehran(dt: datetime) -> datetime:
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=_BAKU_TZ)
-    return dt.astimezone(_BAKU_TZ)
+        return dt.replace(tzinfo=_TEHRAN_TZ)
+    return dt.astimezone(_TEHRAN_TZ)
 
 
 @dataclass(frozen=True)
@@ -106,7 +106,7 @@ class ReleaseBuilder:
         git_sha = self._env.get("GIT_SHA", "unknown")
         build_tag = self._env.get("BUILD_TAG")
         version = resolve_build_version(build_tag, git_sha)
-        build_time = _ensure_baku(self._clock())
+        build_time = _ensure_tehran(self._clock())
 
         wheel_path = release_dir / f"importtosabt-{version}-py3-none-any.whl"
         self._build_wheel(wheel_path=wheel_path, version=version)

--- a/src/phase7_release/sbom.py
+++ b/src/phase7_release/sbom.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Callable, Iterable
 
 from importlib import metadata as importlib_metadata
 
+from src.core.clock import tehran_clock
 from .atomic import atomic_write
 from .hashing import sha256_bytes
 
@@ -53,7 +54,8 @@ def generate_sbom(
 ) -> list[SbomComponent]:
     dists = list(distributions or importlib_metadata.distributions())
     components = sorted((_to_component(dist) for dist in dists), key=lambda item: item.name.lower())
-    now = clock() if clock is not None else datetime.now(tz=timezone.utc)
+    now_factory = clock or tehran_clock().now
+    now = now_factory()
     document = {
         "bomFormat": "CycloneDX",
         "specVersion": "1.4",

--- a/src/reliability/clock.py
+++ b/src/reliability/clock.py
@@ -5,9 +5,14 @@ from dataclasses import dataclass
 from typing import Callable
 from zoneinfo import ZoneInfo
 
+from src.core.clock import tehran_clock
+
+
+_DEFAULT_CLOCK = tehran_clock()
+
 
 def _utc_now() -> _dt.datetime:
-    return _dt.datetime.now(_dt.UTC)
+    return _DEFAULT_CLOCK.now()
 
 
 @dataclass(slots=True)

--- a/src/reliability/config.py
+++ b/src/reliability/config.py
@@ -93,7 +93,7 @@ class ReliabilitySettings(BaseSettings):
     retention: RetentionConfig
     cleanup: CleanupConfig
     tokens: TokenConfig
-    timezone: str = Field(default="Asia/Baku")
+    timezone: str = Field(default="Asia/Tehran")
     rate_limit: RateLimitConfigModel
     idempotency: IdempotencyConfig = Field(default_factory=IdempotencyConfig)
 

--- a/src/ui/pages/students_page.py
+++ b/src/ui/pages/students_page.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Dict, List, Optional
 from datetime import datetime
+from typing import Dict, List, Optional
 
 from PyQt5.QtCore import QAbstractTableModel, QModelIndex, Qt, QTimer, QVariant, pyqtSignal
 from PyQt5.QtGui import QIcon
@@ -34,6 +34,7 @@ from src.services.excel_service import ExcelExportService
 from src.services.excel_import_service import ExcelImportService, ImportValidationResult
 from src.ui.pages.dialogs.export_progress_dialog import ExportProgressDialog, ImportProgressDialog
 from src.ui.pages.dialogs.import_preview_dialog import ImportPreviewDialog
+from src.core.clock import tehran_clock
 from src.ui._safety import is_minimal_mode, log_minimal_mode, swallow_ui_error
 
 
@@ -318,6 +319,7 @@ class StudentsPage(QWidget):
         self.api_client = api_client
         self.event_bus = event_bus
         self.presenter = StudentsPresenter(api_client, event_bus)
+        self._clock = tehran_clock()
 
         # State
         self.current_page = 1
@@ -632,7 +634,7 @@ class StudentsPage(QWidget):
             return
         if not students:
             return
-        dt = datetime.now().strftime("%Y_%m_%d_%H_%M")
+        dt = self._clock.now().strftime("%Y_%m_%d_%H_%M")
         default = f"{prefix}_{dt}.xlsx"
         path, _ = QFileDialog.getSaveFileName(self, "ذخیره فایل اکسل", default, "Excel Files (*.xlsx)")
         if not path:

--- a/src/ui/presenters/main_presenter.py
+++ b/src/ui/presenters/main_presenter.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
-from typing import Literal, Optional
+from typing import Literal
 
 from src.api.client import APIClient
+from src.core.clock import tehran_clock
 from src.ui.core.app_state import AppState
 from src.ui.core.event_bus import EventBus
 
@@ -22,6 +22,7 @@ class MainPresenter:
         self.api_client = api_client
         self.state = AppState(api_mode=("mock" if api_client.use_mock else "real"))
         self.event_bus = EventBus()
+        self.clock = tehran_clock()
 
     async def initialize(self) -> None:
         """بارگذاری اولیه برنامه و بررسی سلامت API."""
@@ -57,7 +58,7 @@ class MainPresenter:
                     elif i == 2:
                         self.state.stats = result
 
-            self.state.last_update = datetime.now()
+            self.state.last_update = self.clock.now()
             await self.event_bus.emit("data_updated", self.state)
         finally:
             await self.event_bus.emit("loading_end")

--- a/src/ui/services/allocation_backend.py
+++ b/src/ui/services/allocation_backend.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import Dict, List, Optional
 
 from faker import Faker
 
 from ...core.models import Mentor, Student
+from ...core.clock import SupportsNow, tehran_clock
 
 
 class IBackendService(ABC):
@@ -33,8 +33,15 @@ class IBackendService(ABC):
 class MockBackendService(IBackendService):
     """Simple in-memory backend used for tests and demos."""
 
-    def __init__(self, *, student_count: int = 150, mentor_count: int = 25) -> None:
+    def __init__(
+        self,
+        *,
+        student_count: int = 150,
+        mentor_count: int = 25,
+        clock: SupportsNow | None = None,
+    ) -> None:
         self._faker = Faker("fa_IR")
+        self._clock = clock or tehran_clock()
         self.students: List[Student] = self._generate_sample_students(student_count)
         self.mentors: List[Mentor] = self._generate_sample_mentors(mentor_count)
         self.assignments: List[Dict[str, object]] = []
@@ -57,7 +64,7 @@ class MockBackendService(IBackendService):
                 record = {
                     "student_id": assignment["student_id"],
                     "mentor_id": assignment["mentor_id"],
-                    "assigned_at": datetime.now(),
+                    "assigned_at": self._clock.now(),
                     "priority_score": assignment.get("priority_score", 0),
                 }
                 self.assignments.append(record)

--- a/src/ui/services/mock_mentor_service.py
+++ b/src/ui/services/mock_mentor_service.py
@@ -1,15 +1,17 @@
 """Mock service for mentor management to support UI development."""
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 import copy
+
+from src.core.clock import SupportsNow, tehran_clock
 
 
 class MockMentorService:
     """In-memory mentor service used during UI prototyping."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, clock: SupportsNow | None = None) -> None:
+        self._clock = clock or tehran_clock()
         self._mentors: List[Dict[str, Any]] = [
             {
                 "id": 1,
@@ -21,7 +23,7 @@ class MockMentorService:
                 "remaining_capacity": 7,
                 "is_active": True,
                 "phone": "09123456789",
-                "created_at": datetime.now(),
+                "created_at": self._clock.now(),
                 "groups": ["کنکوری", "متوسطه دوم"],
             },
             {
@@ -34,7 +36,7 @@ class MockMentorService:
                 "remaining_capacity": 7,
                 "is_active": True,
                 "phone": "09987654321",
-                "created_at": datetime.now(),
+                "created_at": self._clock.now(),
                 "groups": ["متوسطه اول", "دبستان"],
             },
             {
@@ -47,7 +49,7 @@ class MockMentorService:
                 "remaining_capacity": 2,
                 "is_active": True,
                 "phone": "09111222333",
-                "created_at": datetime.now(),
+                "created_at": self._clock.now(),
                 "groups": ["کنکوری", "هنرستان"],
             },
             {
@@ -60,7 +62,7 @@ class MockMentorService:
                 "remaining_capacity": 0,
                 "is_active": False,
                 "phone": "09444555666",
-                "created_at": datetime.now(),
+                "created_at": self._clock.now(),
                 "groups": ["متوسطه اول"],
             },
         ]
@@ -102,7 +104,7 @@ class MockMentorService:
             "remaining_capacity": mentor_data["capacity"],
             "is_active": mentor_data.get("is_active", True),
             "phone": mentor_data.get("phone", ""),
-            "created_at": datetime.now(),
+            "created_at": self._clock.now(),
             "groups": mentor_data.get("groups", []),
             "notes": mentor_data.get("notes", ""),
         }

--- a/src/ui/widgets/analytics_dashboard.py
+++ b/src/ui/widgets/analytics_dashboard.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Dict, Optional
 
 from src.ui.qt_optional import QtCore, QtWidgets, require_qt
@@ -16,6 +15,7 @@ QWidget = QtWidgets.QWidget
 
 from ...services.config_manager import ConfigManager
 from ...services.performance_monitor import PerformanceMonitor
+from ...core.clock import SupportsNow, tehran_clock
 
 
 class AnalyticsDashboard(QWidget):
@@ -27,10 +27,12 @@ class AnalyticsDashboard(QWidget):
         performance_monitor: Optional[PerformanceMonitor] = None,
         config_manager: Optional[ConfigManager] = None,
         parent: Optional[QWidget] = None,
+        clock: SupportsNow | None = None,
     ) -> None:
         super().__init__(parent)
         self.monitor = performance_monitor
         self.config = config_manager or ConfigManager()
+        self._clock = clock or tehran_clock()
         self._allocation_summary: Dict[str, object] = {}
         self._last_refresh = None
         self._build_ui()
@@ -64,7 +66,7 @@ class AnalyticsDashboard(QWidget):
     def refresh_report(self) -> None:
         report = self.generate_text_report()
         self.report_text.setPlainText(report)
-        self._last_refresh = datetime.now()
+        self._last_refresh = self._clock.now()
 
     def generate_text_report(self) -> str:
         stats = self.monitor.get_stats() if self.monitor else {}
@@ -104,7 +106,7 @@ class AnalyticsDashboard(QWidget):
 • استفاده از حافظه: {stats.get('memory_usage', 0.0)}٪
 • مدت فعالیت سیستم: {stats.get('uptime_seconds', 0)} ثانیه
 
-🕒 آخرین بروزرسانی: {datetime.now().strftime('%H:%M:%S')}
+🕒 آخرین بروزرسانی: {self._clock.now().strftime('%H:%M:%S')}
 """
         return report.strip()
 

--- a/tests/downloads/test_signed_url.py
+++ b/tests/downloads/test_signed_url.py
@@ -19,7 +19,7 @@ from src.phase6_import_to_sabt.security.signer import (
 def test_dual_key_acceptance_and_ttl() -> None:
     registry = CollectorRegistry()
     metrics = build_metrics("download_security", registry=registry)
-    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Baku")))
+    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Tehran")))
     keys = SigningKeySet(
         [
             SigningKeyDefinition("ACTV", "a" * 48, "active"),

--- a/tests/export/test_excel_safety_regression.py
+++ b/tests/export/test_excel_safety_regression.py
@@ -40,7 +40,7 @@ def test_formula_injection_guard(tmp_path: Path) -> None:
 def test_always_quote_and_formula_guard(tmp_path: Path) -> None:
     registry = CollectorRegistry()
     metrics = build_import_export_metrics(registry)
-    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Baku")))
+    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Tehran")))
     signer = DualKeySigner(
         keys=SigningKeySet([SigningKeyDefinition("TEST", "S" * 48, "active")]),
         clock=clock,

--- a/tests/exports/test_job_runner_retry_metrics.py
+++ b/tests/exports/test_job_runner_retry_metrics.py
@@ -1,0 +1,164 @@
+"""Integration-grade regression tests for exporter retry/backoff and state hygiene."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from phase6_import_to_sabt.clock import FixedClock
+from phase6_import_to_sabt.job_runner import ExportJobRunner
+from phase6_import_to_sabt.metrics import ExporterMetrics
+from phase6_import_to_sabt.models import (
+    ExportFilters,
+    ExportJobStatus,
+    ExportOptions,
+    ExportSnapshot,
+)
+from phase6_import_to_sabt.sanitization import deterministic_jitter
+from tests.export.helpers import build_exporter, make_row
+
+if TYPE_CHECKING:  # pragma: no cover - typing support only
+    from tests.fixtures.state import CleanupFixtures
+
+pytest_plugins = ["tests.fixtures.state"]
+
+
+@dataclass
+class _FlakyExporter:
+    """Proxy exporter that fails deterministically before succeeding."""
+
+    delegate: Callable[..., object]
+    failures: int
+    _attempts: int = 0
+
+    def run(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        self._attempts += 1
+        if self._attempts <= self.failures:
+            raise ConnectionError("redis transient outage")
+        return self.delegate(*args, **kwargs)
+
+
+def _build_runner(
+    fixtures: "CleanupFixtures",
+    *,
+    rows: Iterable,
+    clock: FixedClock,
+    sleeper: Callable[[float], None],
+    exporter_failures: int,
+    max_retries: int = 4,
+) -> tuple[ExportJobRunner, ExporterMetrics]:
+    exporter = build_exporter(fixtures.base_dir, rows)
+    flaky = _FlakyExporter(exporter.run, exporter_failures)
+    metrics = ExporterMetrics(fixtures.registry)
+    runner = ExportJobRunner(
+        exporter=flaky,
+        redis=fixtures.redis,
+        metrics=metrics,
+        clock=clock,
+        sleeper=sleeper,
+        max_retries=max_retries,
+    )
+    return runner, metrics
+
+
+def test_export_job_runner_retry_deterministic_backoff(cleanup_fixtures: "CleanupFixtures") -> None:
+    """Transient exporter errors trigger deterministic jitter without leaking state."""
+
+    tz = ZoneInfo("Asia/Tehran")
+    clock = FixedClock(datetime(2024, 3, 20, 9, 0, tzinfo=tz))
+    rows = (make_row(idx=i) for i in range(1, 4))
+    recorded: list[float] = []
+    runner, metrics = _build_runner(
+        cleanup_fixtures,
+        rows=rows,
+        clock=clock,
+        sleeper=recorded.append,
+        exporter_failures=2,
+    )
+
+    filters = ExportFilters(year=1402, center=1)
+    options = ExportOptions(output_format="xlsx")
+    snapshot = ExportSnapshot(marker="snap", created_at=clock.now())
+    job = runner.submit(
+        filters=filters,
+        options=options,
+        idempotency_key=f"retry-{cleanup_fixtures.namespace}",
+        namespace=cleanup_fixtures.namespace,
+        correlation_id=f"rid-{cleanup_fixtures.namespace}",
+    )
+    runner.await_completion(job.id)
+    completed = runner.get_job(job.id)
+
+    assert completed is not None and completed.status is ExportJobStatus.SUCCESS, cleanup_fixtures.context(job=completed)
+    assert recorded == pytest.approx(
+        [
+            deterministic_jitter(0.1, 1, job.id),
+            deterministic_jitter(0.1, 2, job.id),
+        ]
+    ), cleanup_fixtures.context(delays=recorded, job=completed)
+
+    transient_errors = metrics.registry.get_sample_value(
+        "export_errors_total",
+        {"type": "transient", "format": options.output_format},
+    )
+    success_total = metrics.registry.get_sample_value(
+        "export_jobs_total",
+        {"status": ExportJobStatus.SUCCESS.value, "format": options.output_format},
+    )
+    assert transient_errors == pytest.approx(2.0), cleanup_fixtures.context(errors=transient_errors)
+    assert success_total == pytest.approx(1.0), cleanup_fixtures.context(success=success_total)
+    leftovers = list(cleanup_fixtures.base_dir.glob("**/*.part"))
+    assert not leftovers, cleanup_fixtures.context(leftovers=[str(path) for path in leftovers])
+
+
+def test_export_job_runner_retry_exhaustion_records_failure_metrics(
+    cleanup_fixtures: "CleanupFixtures",
+) -> None:
+    """Retry exhaustion emits failure metrics and preserves Redis TTL deterministically."""
+
+    tz = ZoneInfo("Asia/Tehran")
+    clock = FixedClock(datetime(2024, 3, 21, 8, 30, tzinfo=tz))
+    rows = (make_row(idx=i) for i in range(10, 13))
+    recorded: list[float] = []
+    runner, metrics = _build_runner(
+        cleanup_fixtures,
+        rows=rows,
+        clock=clock,
+        sleeper=recorded.append,
+        exporter_failures=5,
+        max_retries=2,
+    )
+
+    filters = ExportFilters(year=1402, center=1)
+    options = ExportOptions(output_format="csv")
+    snapshot = ExportSnapshot(marker="snap-fail", created_at=clock.now())
+    job = runner.submit(
+        filters=filters,
+        options=options,
+        idempotency_key=f"retry-fail-{cleanup_fixtures.namespace}",
+        namespace=cleanup_fixtures.namespace,
+        correlation_id=f"rid-fail-{cleanup_fixtures.namespace}",
+    )
+    runner.await_completion(job.id)
+    failed = runner.get_job(job.id)
+
+    assert failed is not None and failed.status is ExportJobStatus.FAILED, cleanup_fixtures.context(job=failed)
+    redis_key = f"phase6:exports:{cleanup_fixtures.namespace}:retry-fail-{cleanup_fixtures.namespace}"
+    assert cleanup_fixtures.redis.get_ttl(redis_key) == 86_400, cleanup_fixtures.context(redis_key=redis_key)
+    assert recorded == pytest.approx([deterministic_jitter(0.1, 1, job.id)]), cleanup_fixtures.context(delays=recorded)
+
+    failure_total = metrics.registry.get_sample_value(
+        "export_jobs_total",
+        {"status": ExportJobStatus.FAILED.value, "format": options.output_format},
+    )
+    transient_errors = metrics.registry.get_sample_value(
+        "export_errors_total",
+        {"type": "transient", "format": options.output_format},
+    )
+    payload = cleanup_fixtures.redis._hash.get(redis_key, {})  # type: ignore[attr-defined]
+    assert failure_total == pytest.approx(1.0), cleanup_fixtures.context(failure=failure_total, payload=payload)
+    assert transient_errors == pytest.approx(2.0), cleanup_fixtures.context(errors=transient_errors, payload=payload)
+    assert "error" in payload, cleanup_fixtures.context(payload=payload)

--- a/tests/mw/test_middleware_diagnostics_chain.py
+++ b/tests/mw/test_middleware_diagnostics_chain.py
@@ -1,0 +1,109 @@
+"""Deterministic middleware order diagnostics regression tests."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Dict, List
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from phase6_import_to_sabt.app.app_factory import create_application
+from phase6_import_to_sabt.app.clock import FixedClock
+from phase6_import_to_sabt.app.config import AppConfig
+from phase6_import_to_sabt.app.stores import InMemoryKeyValueStore
+from phase6_import_to_sabt.app.timing import DeterministicTimer
+from phase6_import_to_sabt.obs.metrics import build_metrics
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tests.fixtures.state import CleanupFixtures
+
+pytest_plugins = ["tests.fixtures.state"]
+
+
+def _build_context(cleanup: "CleanupFixtures") -> Dict[str, object]:
+    unique = f"diag-{uuid4().hex[:12]}"
+    config = AppConfig(
+        redis={"dsn": "redis://localhost:6379/0", "namespace": f"import_to_sabt_{unique}"},
+        database={"dsn": "postgresql://localhost/import_to_sabt"},
+        auth={
+            "metrics_token": f"metrics-{unique}",
+            "service_token": f"service-{unique}",
+            "tokens_env_var": "TOKENS",
+            "download_signing_keys_env_var": "DOWNLOAD_KEYS",
+            "download_url_ttl_seconds": 900,
+        },
+        timezone="Asia/Tehran",
+        enable_diagnostics=True,
+    )
+    clock = FixedClock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    timer = DeterministicTimer([0.0, 0.0, 0.0])
+    metrics = build_metrics(f"import_to_sabt_{unique}", registry=cleanup.registry)
+    rate_store = InMemoryKeyValueStore(f"rate:{unique}", clock)
+    idem_store = InMemoryKeyValueStore(f"idem:{unique}", clock)
+    return {
+        "config": config,
+        "clock": clock,
+        "timer": timer,
+        "metrics": metrics,
+        "rate_store": rate_store,
+        "idem_store": idem_store,
+        "unique": unique,
+    }
+
+
+def _assert_chain(names: List[str], context: Dict[str, object]) -> None:
+    rate_index = names.index("RateLimitMiddleware")
+    idem_index = names.index("IdempotencyMiddleware")
+    auth_index = names.index("AuthMiddleware")
+    assert rate_index < idem_index < auth_index, {
+        "chain": names,
+        "context": context,
+        "message": "Expected RateLimit → Idempotency → Auth order",
+    }
+
+
+def test_middleware_chain_recorded_rate_limit_idem_auth(
+    cleanup_fixtures: "CleanupFixtures",
+) -> None:
+    """Diagnostics capture the runtime middleware chain deterministically."""
+
+    context = _build_context(cleanup_fixtures)
+    app = create_application(
+        config=context["config"],
+        clock=context["clock"],
+        metrics=context["metrics"],
+        timer=context["timer"],
+        rate_limit_store=context["rate_store"],
+        idempotency_store=context["idem_store"],
+        readiness_probes={},
+    )
+    names = [middleware.cls.__name__ for middleware in app.user_middleware]
+    _assert_chain(names, context)
+
+    headers = {
+        "Idempotency-Key": f"idem-{cleanup_fixtures.namespace}",
+        "X-Client-ID": "0client-123",
+        "Authorization": f"Bearer service-{context['unique']}",
+    }
+    with TestClient(app) as client:
+        response = client.post("/api/jobs", headers=headers, json={"size": "0"})
+        payload = response.json()
+        assert response.status_code == 200, cleanup_fixtures.context(response=response.text, payload=payload)
+        assert payload["middleware_chain"] == ["RateLimit", "Idempotency", "Auth"], cleanup_fixtures.context(payload=payload)
+
+    diagnostics = app.state.diagnostics
+    assert diagnostics["last_chain"] == ["RateLimit", "Idempotency", "Auth"], cleanup_fixtures.context(diagnostics=diagnostics)
+
+    decision_value = context["metrics"].registry.get_sample_value(
+        f"import_to_sabt_{context['unique']}_rate_limit_decision_total",
+        {"decision": "allow"},
+    )
+    idem_value = context["metrics"].registry.get_sample_value(
+        f"import_to_sabt_{context['unique']}_idempotency_hits_total",
+        {"outcome": "miss"},
+    )
+    assert decision_value == pytest.approx(1.0), cleanup_fixtures.context(decision=decision_value)
+    assert idem_value == pytest.approx(1.0), cleanup_fixtures.context(idempotency=idem_value)
+
+    context["rate_store"]._store.clear()  # type: ignore[attr-defined]
+    context["idem_store"]._store.clear()  # type: ignore[attr-defined]

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -34,7 +34,7 @@ class StaticConnection:
 
 class FrozenClock:
     def __init__(self) -> None:
-        self._now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Baku"))
+        self._now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Tehran"))
 
     def now(self) -> dt.datetime:
         return self._now

--- a/tests/ops/test_rotation_dual_key.py
+++ b/tests/ops/test_rotation_dual_key.py
@@ -35,7 +35,7 @@ def test_accepts_active_and_next(monkeypatch, capsys) -> None:
 
     registry = CollectorRegistry()
     metrics = build_metrics("rotation_ops", registry=registry)
-    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Baku")))
+    clock = FixedClock(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("Asia/Tehran")))
     signer = DualKeySigner(
         keys=SigningKeySet(settings.signing_keys),
         clock=clock,

--- a/tests/phase6_import_to_sabt/access_helpers.py
+++ b/tests/phase6_import_to_sabt/access_helpers.py
@@ -79,7 +79,7 @@ def access_test_app(
 
     registry = registry or CollectorRegistry()
     metrics = build_metrics(namespace, registry=registry)
-    clock = FixedClock(datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Baku")))
+    clock = FixedClock(datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Tehran")))
     scripted_durations = list(timer_durations) if timer_durations is not None else [0.001, 0.001, 0.001]
     timer = DeterministicTimer(scripted_durations)
     rate_limit_store = InMemoryKeyValueStore(namespace=f"{namespace}:rate", clock=clock)
@@ -97,7 +97,7 @@ def access_test_app(
         ),
         ratelimit=RateLimitConfig(namespace=namespace, requests=100, window_seconds=60, penalty_seconds=60),
         observability=ObservabilityConfig(service_name="import-to-sabt-test", metrics_namespace=namespace),
-        timezone="Asia/Baku",
+        timezone="Asia/Tehran",
         readiness_timeout_seconds=0.1,
         health_timeout_seconds=0.1,
         enable_debug_logs=True,

--- a/tests/phase9_readiness/conftest.py
+++ b/tests/phase9_readiness/conftest.py
@@ -74,7 +74,7 @@ def metrics(clean_state: dict[str, Any]) -> ReadinessMetrics:
 
 @pytest.fixture(scope="function")
 def clock() -> Clock:
-    return Clock(ZoneInfo("Asia/Baku"))
+    return Clock(ZoneInfo("Asia/Tehran"))
 
 
 @pytest.fixture(scope="function")

--- a/tests/pilot/test_pilot_streaming_meter.py
+++ b/tests/pilot/test_pilot_streaming_meter.py
@@ -22,7 +22,7 @@ class CountingIterable:
 
 
 def test_streaming_no_buffer_blowup(tmp_path) -> None:
-    clock = Clock(ZoneInfo("Asia/Baku"), lambda: datetime(2024, 3, 20, 10, tzinfo=ZoneInfo("UTC")))
+    clock = Clock(ZoneInfo("Asia/Tehran"), lambda: datetime(2024, 3, 20, 10, tzinfo=ZoneInfo("UTC")))
     source = CountingIterable(2000)
     meter = StreamingPilotMeter(source=source, clock=clock, tmp_root=tmp_path / "spool")
     stats = meter.prepare()

--- a/tests/retention/test_retention_policy_check.py
+++ b/tests/retention/test_retention_policy_check.py
@@ -31,7 +31,7 @@ def test_retention_fs_timestamp_validation(tmp_path) -> None:
     set_times(old, 30)
 
     policy = RetentionPolicy(max_age_days=7, max_total_size_mb=1, keep_latest=1, enforce=True)
-    clock = Clock(ZoneInfo("Asia/Baku"), lambda: now)
+    clock = Clock(ZoneInfo("Asia/Tehran"), lambda: now)
     validator = RetentionValidator(root=backups_root, clock=clock, policy=policy)
 
     result = validator.run()

--- a/tests/time/test_clock_injection.py
+++ b/tests/time/test_clock_injection.py
@@ -12,7 +12,7 @@ from ops.replica_adapter import ReplicaAdapter
 class FrozenClock:
     def __init__(self) -> None:
         self.calls = 0
-        self._moment = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Baku"))
+        self._moment = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("Asia/Tehran"))
 
     def now(self) -> dt.datetime:
         self.calls += 1


### PR DESCRIPTION
## Summary
- replace all Asia/Baku references with Asia/Tehran and wire shared clock factories into release, ops, reliability, and audit tooling
- inject the Tehran clock throughout signing, logging, analytics/report services, and PyQt UI components to eliminate direct datetime.now usage
- refresh tests to freeze time with the Tehran zone for deterministic export manifests and signed link behaviour
- add deterministic exporter retry/backoff integration tests and middleware diagnostics coverage while extending the evidence map for state hygiene gates

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c pytest.min.ini -q tests/exports/test_job_runner_retry_metrics.py tests/mw/test_middleware_diagnostics_chain.py`


------
https://chatgpt.com/codex/tasks/task_e_68dfe13e85988321a5f05a9128fdb521