### PR TITLE
Fix pytest runner import and declare structlog dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "packaging>=23.2",
     "platformdirs>=3.11",
     "jsonschema>=4.23",
+    "structlog>=24.1",
 ]
 
 [project.optional-dependencies]

--- a/src/ci_runner/exec_pytest.py
+++ b/src/ci_runner/exec_pytest.py
@@ -12,10 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
 
-from .bootstrap import BootstrapError, bilingual_message
+from .bootstrap import BootstrapError
 from .evidence import EvidenceLedger, EvidenceResult, verify_evidence
 from .fs_atomic import atomic_write_text, ensure_directories, rotate_directory
-from .logging_utils import correlation_id, log_event
+from .logging_utils import bilingual_message, correlation_id, log_event
 from .redis_utils import RedisHandle
 from .schemas import validate_pytest_json
 


### PR DESCRIPTION
## Summary
- import `bilingual_message` from `logging_utils` in the pytest runner to avoid bootstrap import errors
- add `structlog` to the project dependencies so structured logging works in fresh environments

## Testing
- `python -m compileall src/ci_runner scripts/verify_env.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0913cd4848321a2dae6109bd70916