### PR TITLE
Add structlog dependency and fix pytest bilingual import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "SQLAlchemy>=2.0,<3",
     "redis>=5,<6",
     "prometheus-client>=0.19",
+    "structlog>=24,<25",
     "openpyxl>=3.1,<4",
     "XlsxWriter>=3.1,<4",
     "jdatetime>=4.1,<5",

--- a/src/ci_runner/exec_pytest.py
+++ b/src/ci_runner/exec_pytest.py
@@ -12,10 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
 
-from .bootstrap import BootstrapError, bilingual_message
+from .bootstrap import BootstrapError
 from .evidence import EvidenceLedger, EvidenceResult, verify_evidence
 from .fs_atomic import atomic_write_text, ensure_directories, rotate_directory
-from .logging_utils import correlation_id, log_event
+from .logging_utils import bilingual_message, correlation_id, log_event
 from .redis_utils import RedisHandle
 from .schemas import validate_pytest_json
 


### PR DESCRIPTION
## Summary
- add structlog to the core dependency list so the logging helpers resolve at runtime
- import `bilingual_message` from the logging utilities in the pytest runner to avoid bootstrap import errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0914aa3608321b0c767ce56ead820