### PR TITLE
Add MatrixCore eligibility and capacity pipeline

### DIFF
--- a/scripts/win/install_and_run.ps1
+++ b/scripts/win/install_and_run.ps1
@@ -2,7 +2,7 @@
 <#!
     Self-healing installer/runner for ImportToSabt on Windows 10/11.
     Execute block-by-block in PowerShell 7+; CI can pass switches for headless mode.
-!>
+#>
 
 [CmdletBinding()]
 param(

--- a/src/app/core/matrix/build_matrix_core.py
+++ b/src/app/core/matrix/build_matrix_core.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+from app.core.matrix.capacity_gates import CapacityResult, evaluate_capacity
+from app.core.matrix.eligibility_rules import EligibilityResult, evaluate_eligibility
+from app.core.matrix.matrix_schema import (
+    CAPACITY_COLUMNS,
+    JOIN_KEY_COLUMNS,
+    MatrixSchema,
+)
+
+
+def _assert_columns(frame: pd.DataFrame, required: Iterable[str], role: str) -> None:
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        missing_fields = ", ".join(sorted(missing))
+        raise ValueError(f"Missing {role} field(s): {missing_fields}")  # noqa: TRY003
+
+
+def _validate_canonical_inputs(
+    mentor_frame: pd.DataFrame, student_frame: pd.DataFrame
+) -> None:
+    mentor_fields: tuple[str, ...] = (
+        "mentor_id",
+        *JOIN_KEY_COLUMNS,
+        *CAPACITY_COLUMNS[:3],
+    )
+    student_fields: tuple[str, ...] = ("student_id", *JOIN_KEY_COLUMNS)
+
+    _assert_columns(mentor_frame, mentor_fields, "mentor")
+    _assert_columns(student_frame, student_fields, "student")
+
+
+def _merge_candidates(
+    mentor_frame: pd.DataFrame, student_frame: pd.DataFrame
+) -> pd.DataFrame:
+    return mentor_frame.merge(
+        student_frame,
+        on=list(JOIN_KEY_COLUMNS),
+        suffixes=("_mentor", "_student"),
+    )
+
+
+def build_matrix_core(
+    mentor_frame: pd.DataFrame, student_frame: pd.DataFrame
+) -> pd.DataFrame:
+    _validate_canonical_inputs(mentor_frame, student_frame)
+
+    merged = _merge_candidates(mentor_frame, student_frame)
+    rows: list[dict[str, object]] = []
+
+    for _, row in merged.iterrows():
+        mentor_fields = {
+            "mentor_id": int(row["mentor_id"]),
+            **{key: int(row[key]) for key in JOIN_KEY_COLUMNS},
+            "capacity_limit": int(row["capacity_limit"]),
+            "assigned_baseline": int(row.get("assigned_baseline", 0)),
+            "allocations_new": int(row.get("allocations_new", 0)),
+            "is_active": row.get("is_active", True),
+            "is_frozen": row.get("is_frozen", False),
+        }
+        mentor = pd.Series(mentor_fields)
+
+        student_fields = {
+            "student_id": int(row["student_id"]),
+            **{key: int(row[key]) for key in JOIN_KEY_COLUMNS},
+        }
+        student = pd.Series(student_fields)
+
+        eligibility: EligibilityResult = evaluate_eligibility(mentor, student)
+        if not eligibility.is_eligible:
+            continue
+
+        capacity: CapacityResult = evaluate_capacity(mentor)
+        trace = list(eligibility.trace)
+        trace[-1] = (
+            "capacity_gate:blocked"
+            if capacity.capacity_blocking
+            else "capacity_gate:pass"
+        )
+
+        qa_flags = (*eligibility.qa_flags, *capacity.qa_flags)
+
+        matrix_row = {
+            "mentor_id": int(mentor["mentor_id"]),
+            "student_id": int(student["student_id"]),
+            **{key: int(mentor[key]) for key in JOIN_KEY_COLUMNS},
+            "capacity_limit": int(mentor["capacity_limit"]),
+            "assigned_baseline": int(mentor.get("assigned_baseline", 0)),
+            "allocations_new": int(mentor.get("allocations_new", 0)),
+            "total_allocations": capacity.total_allocations,
+            "remaining_capacity": capacity.remaining_capacity,
+            "is_eligible": eligibility.is_eligible,
+            "capacity_blocking": capacity.capacity_blocking,
+            "qa_flags": tuple(qa_flags),
+            "trace": tuple(trace),
+        }
+
+        if capacity.can_allocate():
+            rows.append(matrix_row)
+
+    matrix_df = pd.DataFrame(rows)
+    if not matrix_df.empty:
+        matrix_df = matrix_df.sort_values(
+            by=["remaining_capacity", "allocations_new", "mentor_id"],
+            ascending=[False, True, True],
+        ).reset_index(drop=True)
+
+    return MatrixSchema.ensure_schema(matrix_df)
+

--- a/src/app/core/matrix/capacity_gates.py
+++ b/src/app/core/matrix/capacity_gates.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from app.core.matrix.matrix_schema import CAPACITY_COLUMNS
+
+
+@dataclass(frozen=True)
+class CapacityResult:
+    remaining_capacity: int
+    total_allocations: int
+    capacity_blocking: bool
+    qa_flags: tuple[str, ...]
+
+    def can_allocate(self) -> bool:
+        return not self.capacity_blocking and self.remaining_capacity > 0
+
+
+def _ensure_capacity_fields(series: pd.Series) -> None:
+    missing = [column for column in CAPACITY_COLUMNS[:3] if column not in series]
+    if missing:
+        missing_fields = ", ".join(sorted(missing))
+        raise ValueError(f"Missing capacity fields: {missing_fields}")  # noqa: TRY003
+
+
+def evaluate_capacity(mentor: pd.Series) -> CapacityResult:
+    _ensure_capacity_fields(mentor)
+
+    capacity_limit = int(mentor["capacity_limit"])
+    assigned_baseline = int(mentor.get("assigned_baseline", 0))
+    allocations_new = int(mentor.get("allocations_new", 0))
+
+    total_allocations = assigned_baseline + allocations_new
+    remaining_capacity = capacity_limit - total_allocations
+
+    qa_flags: list[str] = []
+    capacity_blocking = False
+
+    if mentor.get("is_frozen", False):
+        capacity_blocking = True
+        qa_flags.append("mentor_frozen")
+
+    if capacity_limit < 0:
+        capacity_blocking = True
+        qa_flags.append("capacity_limit_negative")
+
+    if remaining_capacity < 0:
+        capacity_blocking = True
+        qa_flags.append("remaining_capacity_negative")
+
+    return CapacityResult(
+        remaining_capacity=remaining_capacity,
+        total_allocations=total_allocations,
+        capacity_blocking=capacity_blocking,
+        qa_flags=tuple(qa_flags),
+    )
+

--- a/src/app/core/matrix/eligibility_rules.py
+++ b/src/app/core/matrix/eligibility_rules.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from app.core.matrix.matrix_schema import JOIN_KEY_COLUMNS, TRACE_STEPS
+
+
+@dataclass(frozen=True)
+class EligibilityResult:
+    is_eligible: bool
+    qa_flags: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    trace: tuple[str, ...]
+
+    def can_continue(self) -> bool:
+        return self.is_eligible and not self.blocking_reasons
+
+
+def _ensure_join_keys(series: pd.Series) -> None:
+    missing = [column for column in JOIN_KEY_COLUMNS if column not in series]
+    if missing:
+        missing_keys = ", ".join(missing)
+        raise ValueError(  # noqa: TRY003
+            f"Missing required join keys: {missing_keys}"
+        )
+
+
+def evaluate_eligibility(mentor: pd.Series, student: pd.Series) -> EligibilityResult:
+    _ensure_join_keys(mentor)
+    _ensure_join_keys(student)
+
+    blocking_reasons: list[str] = []
+    qa_flags: list[str] = []
+
+    steps: list[str] = list(TRACE_STEPS)
+
+    if not bool(mentor.get("is_active", True)):
+        blocking_reasons.append("mentor_inactive")
+        steps[0] = "type:inactive"
+
+    if mentor["group_code"] != student["group_code"]:
+        blocking_reasons.append("group_mismatch")
+        steps[1] = "group:blocked"
+
+    mentor_gender = int(mentor["gender_code"])
+    student_gender = int(student["gender_code"])
+    if mentor_gender not in (0, student_gender):
+        blocking_reasons.append("gender_mismatch")
+        steps[2] = "gender:blocked"
+
+    mentor_grad = int(mentor["grad_status_code"])
+    student_grad = int(student["grad_status_code"])
+    if mentor_grad not in (0, student_grad):
+        blocking_reasons.append("graduation_status_mismatch")
+        steps[3] = "graduation_status:blocked"
+
+    mentor_center = int(mentor["center_code"])
+    student_center = int(student["center_code"])
+    if mentor_center not in (0, student_center):
+        blocking_reasons.append("center_mismatch")
+        steps[4] = "center:blocked"
+
+    if int(mentor["finance_code"]) != int(student["finance_code"]):
+        blocking_reasons.append("finance_mismatch")
+        steps[5] = "finance:blocked"
+
+    mentor_school = int(mentor["school_code"])
+    student_school = int(student["school_code"])
+    if mentor_school not in (0, student_school):
+        qa_flags.append("school_mismatch_soft")
+        steps[6] = "school:soft"
+
+    is_eligible = not blocking_reasons
+    return EligibilityResult(
+        is_eligible=is_eligible,
+        qa_flags=tuple(qa_flags),
+        blocking_reasons=tuple(blocking_reasons),
+        trace=tuple(steps),
+    )
+

--- a/src/app/core/matrix/matrix_schema.py
+++ b/src/app/core/matrix/matrix_schema.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+import pandas as pd
+
+JOIN_KEY_COLUMNS: tuple[str, ...] = (
+    "group_code",
+    "gender_code",
+    "grad_status_code",
+    "center_code",
+    "finance_code",
+    "school_code",
+)
+
+CAPACITY_COLUMNS: tuple[str, ...] = (
+    "capacity_limit",
+    "assigned_baseline",
+    "allocations_new",
+    "total_allocations",
+    "remaining_capacity",
+)
+
+TRACE_STEPS: tuple[str, ...] = (
+    "type",
+    "group",
+    "gender",
+    "graduation_status",
+    "center",
+    "finance",
+    "school",
+    "capacity_gate",
+)
+
+
+@dataclass(frozen=True)
+class MatrixRow:
+    mentor_id: int
+    student_id: int
+    group_code: int
+    gender_code: int
+    grad_status_code: int
+    center_code: int
+    finance_code: int
+    school_code: int
+    capacity_limit: int
+    assigned_baseline: int
+    allocations_new: int
+    total_allocations: int
+    remaining_capacity: int
+    is_eligible: bool
+    capacity_blocking: bool
+    qa_flags: tuple[str, ...]
+    trace: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "mentor_id": self.mentor_id,
+            "student_id": self.student_id,
+            "group_code": self.group_code,
+            "gender_code": self.gender_code,
+            "grad_status_code": self.grad_status_code,
+            "center_code": self.center_code,
+            "finance_code": self.finance_code,
+            "school_code": self.school_code,
+            "capacity_limit": self.capacity_limit,
+            "assigned_baseline": self.assigned_baseline,
+            "allocations_new": self.allocations_new,
+            "total_allocations": self.total_allocations,
+            "remaining_capacity": self.remaining_capacity,
+            "is_eligible": self.is_eligible,
+            "capacity_blocking": self.capacity_blocking,
+            "qa_flags": self.qa_flags,
+            "trace": self.trace,
+        }
+
+
+class MatrixSchema:
+    """Utility helpers for validating MatrixCore DataFrame payloads."""
+
+    @staticmethod
+    def required_columns() -> Iterable[str]:
+        yield from (
+            "mentor_id",
+            "student_id",
+            *JOIN_KEY_COLUMNS,
+            *CAPACITY_COLUMNS,
+            "is_eligible",
+            "capacity_blocking",
+            "qa_flags",
+            "trace",
+        )
+
+    @classmethod
+    def ensure_schema(cls, df: pd.DataFrame) -> pd.DataFrame:
+        filled = df.copy()
+        for column in cls.required_columns():
+            if column not in filled.columns:
+                filled[column] = pd.NA
+        return filled
+
+    @staticmethod
+    def validate_trace(trace: Sequence[str]) -> bool:
+        return tuple(trace) == TRACE_STEPS or len(trace) == len(TRACE_STEPS)
+

--- a/tests/integration/test_matrix_core_end_to_end.py
+++ b/tests/integration/test_matrix_core_end_to_end.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.core.matrix.build_matrix_core import build_matrix_core
+from app.core.matrix.matrix_schema import (
+    CAPACITY_COLUMNS,
+    JOIN_KEY_COLUMNS,
+    TRACE_STEPS,
+)
+
+
+@pytest.fixture
+def mentor_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "mentor_id": 1,
+                "group_code": 10,
+                "gender_code": 1,
+                "grad_status_code": 2,
+                "center_code": 5,
+                "finance_code": 3,
+                "school_code": 7,
+                "capacity_limit": 3,
+                "assigned_baseline": 1,
+                "allocations_new": 0,
+                "is_active": True,
+            },
+            {
+                "mentor_id": 2,
+                "group_code": 10,
+                "gender_code": 1,
+                "grad_status_code": 2,
+                "center_code": 5,
+                "finance_code": 3,
+                "school_code": 7,
+                "capacity_limit": 1,
+                "assigned_baseline": 1,
+                "allocations_new": 0,
+                "is_active": True,
+            },
+        ]
+    )
+
+
+@pytest.fixture
+def student_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "student_id": 100,
+                "group_code": 10,
+                "gender_code": 1,
+                "grad_status_code": 2,
+                "center_code": 5,
+                "finance_code": 3,
+                "school_code": 7,
+            },
+            {
+                "student_id": 200,
+                "group_code": 10,
+                "gender_code": 1,
+                "grad_status_code": 2,
+                "center_code": 5,
+                "finance_code": 3,
+                "school_code": 7,
+            },
+        ]
+    )
+
+
+def test_matrix_builds_and_orders(
+    mentor_frame: pd.DataFrame, student_frame: pd.DataFrame
+) -> None:
+    matrix = build_matrix_core(mentor_frame, student_frame)
+
+    assert list(matrix.columns[: len(JOIN_KEY_COLUMNS)])
+    assert {"mentor_id", "student_id"}.issubset(matrix.columns)
+    assert set(CAPACITY_COLUMNS).issubset(matrix.columns)
+
+    expected_rows = 2
+    assert len(matrix) == expected_rows
+    assert matrix.loc[0, "remaining_capacity"] >= matrix.loc[1, "remaining_capacity"]
+    assert matrix["trace"].apply(lambda trace: len(trace) == len(TRACE_STEPS)).all()
+
+
+def test_capacity_gate_blocks_full_mentor(
+    mentor_frame: pd.DataFrame, student_frame: pd.DataFrame
+) -> None:
+    matrix = build_matrix_core(mentor_frame, student_frame)
+
+    full_capacity_id = 2
+    assert (matrix["mentor_id"] == full_capacity_id).sum() == 0
+
+
+def test_missing_join_key_fails_fast(
+    mentor_frame: pd.DataFrame, student_frame: pd.DataFrame
+) -> None:
+    broken_students = student_frame.drop(columns=["group_code"])
+
+    with pytest.raises(ValueError):
+        build_matrix_core(mentor_frame, broken_students)
+

--- a/tests/unit/test_matrix_core_capacity_gates.py
+++ b/tests/unit/test_matrix_core_capacity_gates.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.core.matrix.capacity_gates import evaluate_capacity
+
+
+def test_capacity_computation_allows() -> None:
+    mentor = pd.Series(
+        {
+            "capacity_limit": 5,
+            "assigned_baseline": 1,
+            "allocations_new": 1,
+        }
+    )
+
+    result = evaluate_capacity(mentor)
+
+    expected_remaining = 3
+    assert result.remaining_capacity == expected_remaining
+    assert result.capacity_blocking is False
+    assert result.qa_flags == ()
+
+
+def test_frozen_mentor_blocks_capacity() -> None:
+    mentor = pd.Series(
+        {
+            "capacity_limit": 2,
+            "assigned_baseline": 1,
+            "allocations_new": 0,
+            "is_frozen": True,
+        }
+    )
+
+    result = evaluate_capacity(mentor)
+
+    assert result.capacity_blocking is True
+    assert "mentor_frozen" in result.qa_flags
+
+
+def test_negative_remaining_capacity_blocks() -> None:
+    mentor = pd.Series(
+        {
+            "capacity_limit": 1,
+            "assigned_baseline": 1,
+            "allocations_new": 2,
+        }
+    )
+
+    result = evaluate_capacity(mentor)
+
+    assert result.capacity_blocking is True
+    negative_capacity = -2
+    assert result.remaining_capacity == negative_capacity
+    assert "remaining_capacity_negative" in result.qa_flags
+
+
+def test_missing_capacity_field_raises() -> None:
+    mentor = pd.Series({"capacity_limit": 1, "assigned_baseline": 1})
+
+    with pytest.raises(ValueError):
+        evaluate_capacity(mentor)
+

--- a/tests/unit/test_matrix_core_eligibility.py
+++ b/tests/unit/test_matrix_core_eligibility.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.core.matrix.eligibility_rules import evaluate_eligibility
+from app.core.matrix.matrix_schema import TRACE_STEPS
+
+
+@pytest.fixture
+def mentor_base() -> pd.Series:
+    return pd.Series(
+        {
+            "mentor_id": 1,
+            "group_code": 10,
+            "gender_code": 1,
+            "grad_status_code": 2,
+            "center_code": 5,
+            "finance_code": 3,
+            "school_code": 7,
+            "is_active": True,
+        }
+    )
+
+
+@pytest.fixture
+def student_base() -> pd.Series:
+    return pd.Series(
+        {
+            "student_id": 99,
+            "group_code": 10,
+            "gender_code": 1,
+            "grad_status_code": 2,
+            "center_code": 5,
+            "finance_code": 3,
+            "school_code": 7,
+        }
+    )
+
+
+def test_happy_path_eligibility(
+    mentor_base: pd.Series, student_base: pd.Series
+) -> None:
+    result = evaluate_eligibility(mentor_base, student_base)
+
+    assert result.is_eligible is True
+    assert result.blocking_reasons == ()
+    assert result.qa_flags == ()
+    assert result.trace[: len(TRACE_STEPS)] == TRACE_STEPS
+
+
+def test_gender_mismatch_blocks(
+    mentor_base: pd.Series, student_base: pd.Series
+) -> None:
+    student = student_base.copy()
+    student["gender_code"] = 2
+
+    result = evaluate_eligibility(mentor_base, student)
+
+    assert result.is_eligible is False
+    assert "gender_mismatch" in result.blocking_reasons
+
+
+def test_center_wildcard_allows(
+    mentor_base: pd.Series, student_base: pd.Series
+) -> None:
+    mentor = mentor_base.copy()
+    mentor["center_code"] = 0
+
+    result = evaluate_eligibility(mentor, student_base)
+
+    assert result.is_eligible is True
+    assert result.blocking_reasons == ()
+
+
+def test_missing_join_key_raises(
+    mentor_base: pd.Series, student_base: pd.Series
+) -> None:
+    incomplete_student = student_base.drop(labels=["center_code"])
+
+    with pytest.raises(ValueError):
+        evaluate_eligibility(mentor_base, incomplete_student)
+


### PR DESCRIPTION
## Summary
- add MatrixCore schema helpers and explicit eligibility and capacity gate evaluation
- build a deterministic matrix core builder that filters on eligibility and capacity while preserving join keys and trace
- cover eligibility, capacity, and end-to-end matrix construction with new unit and integration tests

## Testing
- PYENV_VERSION=3.11.12 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/test_matrix_core_eligibility.py tests/unit/test_matrix_core_capacity_gates.py tests/integration/test_matrix_core_end_to_end.py
- PYENV_VERSION=3.11.12 ruff check src/app/core/matrix tests/unit/test_matrix_core_eligibility.py tests/unit/test_matrix_core_capacity_gates.py tests/integration/test_matrix_core_end_to_end.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938230ad4288321b22c13ddfe257c65)